### PR TITLE
Fix graph relies on pulse

### DIFF
--- a/app/lib/features/statistics/value_graph.dart
+++ b/app/lib/features/statistics/value_graph.dart
@@ -38,9 +38,9 @@ class BloodPressureValueGraph extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (records.sysGraph().length <= 2
-      || records.diaGraph().length <= 2
-      || records.pulGraph().length <= 2) {
+    if (records.sysGraph().length < 2
+      && records.diaGraph().length < 2
+      && records.pulGraph().length < 2) {
       return Center(
         child: Text(AppLocalizations.of(context)!.errNotEnoughDataToGraph),
       );
@@ -198,6 +198,8 @@ class _ValueGraphPainter extends CustomPainter {
     double maxY,
     double? warnValue,
   ) {
+    if (data.isEmpty) return;
+
     Path? path;
     for (final e in data) {
       final point = ui.Offset(_transformX(size, e.$1, range), _transformY(size, e.$2, minY, maxY));

--- a/app/test/features/statistics/value_graph_test.dart
+++ b/app/test/features/statistics/value_graph_test.dart
@@ -102,6 +102,31 @@ void main() {
 
     await expectLater(find.byType(BloodPressureValueGraph), matchesGoldenFile('full_graph-years.png'));
   });
+
+  testWidgets('BloodPressureValueGraph is fine with enough values in sys category', (tester) async {
+    await tester.pumpWidget(_buildGraph([
+      mockRecord(time: DateTime(2005), sys: 123),
+      mockRecord(time: DateTime(2003), sys: 110),
+    ], [], []));
+    final localizations = await AppLocalizations.delegate.load(const Locale('en'));
+    expect(find.text(localizations.errNotEnoughDataToGraph), findsNothing);
+  });
+  testWidgets('BloodPressureValueGraph is fine with enough values in dia category', (tester) async {
+    await tester.pumpWidget(_buildGraph([
+      mockRecord(time: DateTime(2005), dia: 123),
+      mockRecord(time: DateTime(2003), dia: 110),
+    ], [], []));
+    final localizations = await AppLocalizations.delegate.load(const Locale('en'));
+    expect(find.text(localizations.errNotEnoughDataToGraph), findsNothing);
+  });
+  testWidgets('BloodPressureValueGraph is fine with enough values in pul category', (tester) async {
+    await tester.pumpWidget(_buildGraph([
+      mockRecord(time: DateTime(2005), pul: 123),
+      mockRecord(time: DateTime(2003), pul: 110),
+    ], [], []));
+    final localizations = await AppLocalizations.delegate.load(const Locale('en'));
+    expect(find.text(localizations.errNotEnoughDataToGraph), findsNothing);
+  });
 }
 
 Widget _buildGraph(


### PR DESCRIPTION
closes #460

Previously if either category (sys,dia,pul) had less than 3 values the graph wouldn't draw. This didn't make a lot of sense for folks not entering pulse (as [GiovanniManieri](https://github.com/GiovanniManieri) thankfully pointed out), so now the graph is rendered when at least one category has 2 or more values.