### PR TITLE
Fix custom date range ending before midnight

### DIFF
--- a/app/lib/data_util/interval_picker.dart
+++ b/app/lib/data_util/interval_picker.dart
@@ -12,10 +12,18 @@ import 'package:week_of_year/date_week_extensions.dart';
 /// in both directions.
 class IntervalPicker extends StatelessWidget {
   /// Create a selector for [IntervalStorage] values.
-  const IntervalPicker({super.key, required this.type});
+  const IntervalPicker({super.key,
+    required this.type,
+    this.customRangePickerCurrentDay,
+  });
 
   /// Which range to display and modify.
   final IntervalStoreManagerLocation type;
+
+  /// The day from which to start the custom date range picker.
+  ///
+  /// Defaults to the current day which is the desired value in all non-test scenarios.
+  final DateTime? customRangePickerCurrentDay;
   
   @override
   Widget build(BuildContext context) => Consumer<IntervalStoreManager>(
@@ -52,7 +60,8 @@ class IntervalPicker extends StatelessWidget {
                       final res = await showDateRangePicker(
                         context: context,
                         firstDate: DateTime.fromMillisecondsSinceEpoch(1),
-                        lastDate: DateTime.now().copyWith(day: DateTime.now().day + 1),
+                        lastDate: customRangePickerCurrentDay ?? DateTime.now(),
+                        currentDate: customRangePickerCurrentDay,
                       );
                       if (res != null) {
                         intervall.changeStepSize(value!);

--- a/app/lib/data_util/interval_picker.dart
+++ b/app/lib/data_util/interval_picker.dart
@@ -56,7 +56,10 @@ class IntervalPicker extends StatelessWidget {
                       );
                       if (res != null) {
                         intervall.changeStepSize(value!);
-                        intervall.currentRange = res.dateRange;
+                        final dateRange = res.dateRange.copyWith(
+                          end: res.end.copyWith(hour: 23, minute: 59, second: 59),
+                        );
+                        intervall.currentRange = dateRange;
                       }
                     } else if (value != null) {
                       intervall.changeStepSize(value);

--- a/app/lib/data_util/interval_picker.dart
+++ b/app/lib/data_util/interval_picker.dart
@@ -52,7 +52,7 @@ class IntervalPicker extends StatelessWidget {
                       final res = await showDateRangePicker(
                         context: context,
                         firstDate: DateTime.fromMillisecondsSinceEpoch(1),
-                        lastDate: DateTime.now(),
+                        lastDate: DateTime.now().copyWith(day: DateTime.now().day + 1),
                       );
                       if (res != null) {
                         intervall.changeStepSize(value!);

--- a/app/test/data_util/interval_picker_test.dart
+++ b/app/test/data_util/interval_picker_test.dart
@@ -89,7 +89,10 @@ void main() {
 
     await tester.pumpWidget(materialApp(ChangeNotifierProvider.value(
       value: s,
-      child: const IntervalPicker(type: IntervalStoreManagerLocation.mainPage),
+      child: IntervalPicker(
+        type: IntervalStoreManagerLocation.mainPage,
+        customRangePickerCurrentDay: DateTime(2024, 1, 25),
+      ),
     )));
     final localizations = await AppLocalizations.delegate.load(const Locale('en'));
     final materialLocalizations = await DefaultMaterialLocalizations.delegate.load(const Locale('en'));
@@ -100,9 +103,9 @@ void main() {
     await tester.tap(find.text(localizations.custom));
     await tester.pumpAndSettle(); // opens date interval selection
 
-    await tester.tap(find.text('${DateTime.now().day}').last);
+    await tester.tap(find.text('20').first);
     await tester.pump();
-    await tester.tap(find.text('${DateTime.now().day + 1}').last);
+    await tester.tap(find.text('25').first);
     await tester.pump();
     await tester.tap(find.text(materialLocalizations.saveButtonLabel).first);
     await tester.pumpAndSettle();
@@ -110,11 +113,19 @@ void main() {
     expect(find.byType(DateRangePickerDialog), findsNothing);
 
     expect(s.mainPage.stepSize, TimeStep.custom);
-    expect(s.mainPage.currentRange.start.day, DateTime.now().day);
-    expect(s.mainPage.currentRange.end.day, DateTime.now().day + 1);
+    expect(s.mainPage.currentRange.start.year, 2024);
+    expect(s.mainPage.currentRange.start.month, 1);
+    expect(s.mainPage.currentRange.start.day, 20);
+    expect(s.mainPage.currentRange.end.year, 2024);
+    expect(s.mainPage.currentRange.end.month, 1);
+    expect(s.mainPage.currentRange.end.day, 25);
 
     expect(s.mainPage.currentRange.end.hour, 23, reason: 'should always be after newer measurements (#466)');
     expect(s.mainPage.currentRange.end.minute, 59, reason: 'should always be after newer measurements (#466)');
     expect(s.mainPage.currentRange.end.second, 59, reason: 'should always be after newer measurements (#466)');
+
+    expect(s.mainPage.currentRange.start.hour, 0);
+    expect(s.mainPage.currentRange.start.minute, 0);
+    expect(s.mainPage.currentRange.start.second, 0);
   });
 }


### PR DESCRIPTION
When picking custom time the picker didn't ensure the end of the day (23:59:59) is selected, which resulted in newer measurements not being shown (on list and export). 

This PR:
- ensures the time is set to the end of the day
- adds proper testing to interval pickers custom range selection

closes #466