### PR TITLE
Remove avoid_redundant_argument_values lint

### DIFF
--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -17,7 +17,6 @@ linter:
     # consider: https://dart.dev/tools/linter-rules/avoid_bool_literals_in_conditional_expressions
     - avoid_double_and_int_checks
     - avoid_escaping_inner_quotes
-    - avoid_redundant_argument_values
     - directives_ordering
     - eol_at_end_of_file
     - leading_newlines_in_multiline_strings


### PR DESCRIPTION
This PR removes the lint as it has occasional false-positives (as mentioned in [the docs](https://dart.dev/tools/linter-rules/avoid_redundant_argument_values)) and there is no strong reasoning to keep it. 

While it can be used to automatically switch to better defaults, I could even argue that it is equally as likely to be harmful when the default changes. It discourages explicitly enumerating a default value in cases where only the default value makes sense. This way context is effectively lost.