### PR TITLE
Fix multicolumn PDF export missing rows at table breaks

### DIFF
--- a/app/lib/model/export_import/pdf_converter.dart
+++ b/app/lib/model/export_import/pdf_converter.dart
@@ -194,12 +194,13 @@ class PdfConverter {
 
         final List<pw.Widget> tables = [];
         int pageNum = 0;
-        for (int offset = 0; offset < data.length; offset += rowCount) {
+        for (int offset = 0; offset < data.length; offset += (rowCount - 1)) {
           final dataRange = data.getRange(offset, min(offset + rowCount, data.length)).toList();
           // Correct rowcount after first page (2 tables)
           if (pageNum == 1) {
             rowCount = (PdfPageFormat.a4.availableHeight - realHeaderHeight)
                 ~/ (realCellHeight);
+            offset -= 1;
           }
           tables.add(pw.Container(
             padding: const pw.EdgeInsets.symmetric(horizontal: 5),
@@ -248,7 +249,6 @@ class PdfConverter {
           ),);
           pageNum++;
         }
-
 
         return pw.Wrap(
             children: [


### PR DESCRIPTION
When dividing the table for multi-column layout there was a bug in the algorithm: After computing the amount of rows available it increments the current row index by that count and takes the data from *after* the last end index up to, *excluding*, the new end index. While the first one was intentional to avoid negative indexing on the first page, excluding the new end index is entirely unnecessary and was likely introduced during a refactor.

fixes #485