### PR TITLE
Remove f-droid-flutter from pubspec

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -5,8 +5,6 @@ repository: https://github.com/derdilla/blood-pressure-monitor-fl
 issue_tracker: https://github.com/derdilla/blood-pressure-monitor-fl/issues
 
 version: 1.8.5+47
-# F-Droid needs the Flutter version used to build releases to be in the repository.
-# f-droid-flutter: 3.27.3
 
 environment:
   sdk: '>=3.0.2 <4.0.0'


### PR DESCRIPTION
For f-droid to change their scripts a build needs to fail.