### PR TITLE
Allow not trusting bluetooth

### DIFF
--- a/app/lib/features/bluetooth/bluetooth_input.dart
+++ b/app/lib/features/bluetooth/bluetooth_input.dart
@@ -11,11 +11,11 @@ import 'package:blood_pressure_app/features/bluetooth/ui/input_card.dart';
 import 'package:blood_pressure_app/features/bluetooth/ui/measurement_failure.dart';
 import 'package:blood_pressure_app/features/bluetooth/ui/measurement_multiple.dart';
 import 'package:blood_pressure_app/features/bluetooth/ui/measurement_success.dart';
+import 'package:blood_pressure_app/l10n/app_localizations.dart';
 import 'package:blood_pressure_app/logging.dart';
 import 'package:blood_pressure_app/model/storage/storage.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:blood_pressure_app/l10n/app_localizations.dart';
 import 'package:health_data_store/health_data_store.dart';
 
 /// Class for inputting measurement through bluetooth.

--- a/app/lib/features/input/forms/add_entry_form.dart
+++ b/app/lib/features/input/forms/add_entry_form.dart
@@ -268,10 +268,12 @@ class AddEntryFormState extends FormStateBase<AddEntryFormValue, AddEntryForm>
           BluetoothInputMode.newBluetoothInputOldLib => BluetoothInput(
             manager: BluetoothManager.create(BluetoothBackend.flutterBluePlus),
             onMeasurement: _onExternalMeasurement,
+            bluetoothCubit: widget.bluetoothCubit,
           ),
           BluetoothInputMode.newBluetoothInputCrossPlatform => BluetoothInput(
             manager: BluetoothManager.create(BluetoothBackend.bluetoothLowEnergy),
             onMeasurement: _onExternalMeasurement,
+            bluetoothCubit: widget.bluetoothCubit,
           ),
         })(),
         if (settings.allowManualTimeInput)

--- a/app/lib/features/input/forms/add_entry_form.dart
+++ b/app/lib/features/input/forms/add_entry_form.dart
@@ -226,13 +226,20 @@ class AddEntryFormState extends FormStateBase<AddEntryFormValue, AddEntryForm>
   void _onExternalMeasurement(BloodPressureRecord record) {
     final settings = context.read<Settings>();
     if (settings.trustBLETime
-      // TODO: don't show hint too often
+        && settings.showBLETimeTrustDialog
         && record.time.difference(DateTime.now()).inHours.abs() > 5) {
       unawaited(showDialog(context: context, builder: (context) => AlertDialog(
         content: Text(AppLocalizations.of(context)!.warnBLETimeSus(
           record.time.difference(DateTime.now()).inHours
         )),
         actions: [
+          ElevatedButton(
+            onPressed: () {
+              settings.showBLETimeTrustDialog = false;
+              Navigator.pop(context);
+            },
+            child: Text(AppLocalizations.of(context)!.dontShowAgain),
+          ),
           ElevatedButton(
             onPressed: () => Navigator.pop(context),
             child: Text(AppLocalizations.of(context)!.btnConfirm),

--- a/app/lib/features/input/forms/add_entry_form.dart
+++ b/app/lib/features/input/forms/add_entry_form.dart
@@ -227,8 +227,7 @@ class AddEntryFormState extends FormStateBase<AddEntryFormValue, AddEntryForm>
     final settings = context.read<Settings>();
     if (settings.trustBLETime
       // TODO: don't show hint too often
-        && record.time.difference(DateTime.now()).inHours > 5) {
-      // FIXME: this is completely untested
+        && record.time.difference(DateTime.now()).inHours.abs() > 5) {
       unawaited(showDialog(context: context, builder: (context) => AlertDialog(
         content: Text(AppLocalizations.of(context)!.warnBLETimeSus(
           record.time.difference(DateTime.now()).inHours

--- a/app/lib/features/input/forms/add_entry_form.dart
+++ b/app/lib/features/input/forms/add_entry_form.dart
@@ -33,6 +33,8 @@ class AddEntryForm extends FormBase<AddEntryFormValue> with TypeLogger {
   final List<Medicine> meds;
 
   /// Function to customize [BluetoothCubit] creation.
+  ///
+  /// Works on [BluetoothInputMode.newBluetoothInputCrossPlatform].
   @visibleForTesting
   final BluetoothCubit Function()? bluetoothCubit;
 
@@ -212,8 +214,11 @@ class AddEntryFormState extends FormStateBase<AddEntryFormValue, AddEntryForm>
     }
   }
 
+  /// Gets called on inputs from a bluetooth device or similar.
   void _onExternalMeasurement(BloodPressureRecord record) => fillForm((
-    timestamp: record.time,
+    timestamp: context.read<Settings>().trustBLETime
+        ? record.time
+        : _timeForm.currentState?.save() ?? DateTime.now(),
     note: null,
     record: record,
     intake: null,

--- a/app/lib/features/input/forms/add_entry_form.dart
+++ b/app/lib/features/input/forms/add_entry_form.dart
@@ -28,6 +28,7 @@ class AddEntryForm extends FormBase<AddEntryFormValue> with TypeLogger {
     super.initialValue,
     this.meds = const [],
     this.bluetoothCubit,
+    this.mockBleInput,
   });
 
   /// All medicines selectable.
@@ -40,6 +41,10 @@ class AddEntryForm extends FormBase<AddEntryFormValue> with TypeLogger {
   /// Works on [BluetoothInputMode.newBluetoothInputCrossPlatform].
   @visibleForTesting
   final BluetoothCubit Function()? bluetoothCubit;
+
+  /// A builder for a widget that can act as a bluetooth input.
+  @visibleForTesting
+  final Widget Function(void Function(BloodPressureRecord data))? mockBleInput;
 
   @override
   FormStateBase createState() => AddEntryFormState();
@@ -254,6 +259,8 @@ class AddEntryFormState extends FormStateBase<AddEntryFormValue, AddEntryForm>
     return ListView(
       padding: const EdgeInsets.symmetric(horizontal: 8),
       children: [
+        if (widget.mockBleInput != null)
+          widget.mockBleInput!.call(_onExternalMeasurement),
         (() => switch (settings.bleInput) {
           BluetoothInputMode.disabled => SizedBox.shrink(),
           BluetoothInputMode.oldBluetoothInput => OldBluetoothInput(
@@ -262,12 +269,10 @@ class AddEntryFormState extends FormStateBase<AddEntryFormValue, AddEntryForm>
           BluetoothInputMode.newBluetoothInputOldLib => BluetoothInput(
             manager: BluetoothManager.create(BluetoothBackend.flutterBluePlus),
             onMeasurement: _onExternalMeasurement,
-            bluetoothCubit: widget.bluetoothCubit,
           ),
           BluetoothInputMode.newBluetoothInputCrossPlatform => BluetoothInput(
             manager: BluetoothManager.create(BluetoothBackend.bluetoothLowEnergy),
             onMeasurement: _onExternalMeasurement,
-            bluetoothCubit: widget.bluetoothCubit,
           ),
         })(),
         if (settings.allowManualTimeInput)

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -553,9 +553,16 @@
   "@newBluetoothInputCrossPlatform": {},
   "bluetoothInputDesc": "The beta backend works on more devices but is less tested. The cross-platform version may work on non-android and is planned to supersede the stable implementation once mature enough.",
   "@bluetoothInputDesc": {},
-  "@bluetoothInputDesc": {},
   "tapToSelect": "Tap to select",
   "@tapToSelect": {},
   "trustBLETime": "Trust time reported by bluetooth devices",
-  "@trustBLETime": {}
+  "@trustBLETime": {},
+  "warnBLETimeSus": "The bluetooth device reported a time off by {hours} hours. You can disable trusting timestamps from bluetooth devices in the settings.",
+  "@warnBLETimeSus": {
+    "placeholders": {
+      "hours": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -555,5 +555,7 @@
   "@bluetoothInputDesc": {},
   "@bluetoothInputDesc": {},
   "tapToSelect": "Tap to select",
-  "@tapToSelect": {}
+  "@tapToSelect": {},
+  "trustBLETime": "Trust time reported by bluetooth devices",
+  "@trustBLETime": {}
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -564,5 +564,7 @@
         "type": "int"
       }
     }
-  }
+  },
+  "dontShowAgain": "Don''t show again",
+  "@dontShowAgain": {}
 }

--- a/app/lib/model/storage/settings_store.dart
+++ b/app/lib/model/storage/settings_store.dart
@@ -22,6 +22,8 @@ class Settings extends ChangeNotifier {
   /// Creates a settings object with the default values.
   ///
   /// When the values should be set consider using the factory methods.
+  /// Create a instance from a map created by [toMap].
+
   Settings({
     Locale? language,
     Color? accentColor,
@@ -51,6 +53,7 @@ class Settings extends ChangeNotifier {
     BluetoothInputMode? bleInput,
     bool? weightInput,
     WeightUnit? weightUnit,
+    bool? trustBLETime,
   }) {
     if (accentColor != null) _accentColor = accentColor;
     if (sysColor != null) _sysColor = sysColor;
@@ -79,10 +82,9 @@ class Settings extends ChangeNotifier {
     if (bleInput != null) _bleInput = bleInput;
     if (weightInput != null) _weightInput = weightInput;
     if (weightUnit != null) _weightUnit = weightUnit;
+    if (trustBLETime != null) _trustBLETime = trustBLETime;
     _language = language; // No check here, as null is the default as well.
   }
-
-  /// Create a instance from a map created by [toMap].
   factory Settings.fromMap(Map<String, dynamic> map) {
     final settingsObject = Settings(
       accentColor: ConvertUtil.parseColor(map['accentColor']),
@@ -114,6 +116,7 @@ class Settings extends ChangeNotifier {
       weightInput: ConvertUtil.parseBool(map['weightInput']),
       preferredPressureUnit: PressureUnit.decode(ConvertUtil.parseInt(map['preferredPressureUnit'])),
       weightUnit: WeightUnit.deserialize(ConvertUtil.parseInt(map['weightUnit'])),
+      trustBLETime: ConvertUtil.parseBool(map['trustBLETime']),
     );
 
     // update
@@ -162,6 +165,7 @@ class Settings extends ChangeNotifier {
     'bleInput': bleInput.serialize(),
     'weightInput': weightInput,
     'weightUnit': weightUnit.serialized,
+    'trustBLETime': trustBLETime,
   };
 
   /// Serialize the object to a restoreable string.
@@ -197,6 +201,7 @@ class Settings extends ChangeNotifier {
     _highestMedIndex = other._highestMedIndex;
     _weightInput = other._weightInput;
     _weightUnit = other._weightUnit;
+    _trustBLETime = other._trustBLETime;
     notifyListeners();
   }
 
@@ -441,7 +446,17 @@ class Settings extends ChangeNotifier {
     _weightUnit = value;
     notifyListeners();
   }
-  
+
+
+  bool _trustBLETime = true;
+  /// Whether to autofill the time the bluetooth device reports.
+  ///
+  /// This was introduced because the system time tends to be more accurate.
+  bool get trustBLETime => _trustBLETime;
+  set trustBLETime(bool value) {
+    _trustBLETime = value;
+    notifyListeners();
+  }
 // When adding fields notice the checklist at the top.
 }
 

--- a/app/lib/model/storage/settings_store.dart
+++ b/app/lib/model/storage/settings_store.dart
@@ -54,6 +54,7 @@ class Settings extends ChangeNotifier {
     bool? weightInput,
     WeightUnit? weightUnit,
     bool? trustBLETime,
+    bool? showBLETimeTrustDialog,
   }) {
     if (accentColor != null) _accentColor = accentColor;
     if (sysColor != null) _sysColor = sysColor;
@@ -83,6 +84,7 @@ class Settings extends ChangeNotifier {
     if (weightInput != null) _weightInput = weightInput;
     if (weightUnit != null) _weightUnit = weightUnit;
     if (trustBLETime != null) _trustBLETime = trustBLETime;
+    if (showBLETimeTrustDialog != null) _showBLETimeTrustDialog = showBLETimeTrustDialog;
     _language = language; // No check here, as null is the default as well.
   }
   factory Settings.fromMap(Map<String, dynamic> map) {
@@ -117,6 +119,7 @@ class Settings extends ChangeNotifier {
       preferredPressureUnit: PressureUnit.decode(ConvertUtil.parseInt(map['preferredPressureUnit'])),
       weightUnit: WeightUnit.deserialize(ConvertUtil.parseInt(map['weightUnit'])),
       trustBLETime: ConvertUtil.parseBool(map['trustBLETime']),
+      showBLETimeTrustDialog: ConvertUtil.parseBool(map['showBLETimeTrustDialog']),
     );
 
     // update
@@ -166,6 +169,7 @@ class Settings extends ChangeNotifier {
     'weightInput': weightInput,
     'weightUnit': weightUnit.serialized,
     'trustBLETime': trustBLETime,
+    'showBLETimeTrustDialog': showBLETimeTrustDialog,
   };
 
   /// Serialize the object to a restoreable string.
@@ -202,6 +206,7 @@ class Settings extends ChangeNotifier {
     _weightInput = other._weightInput;
     _weightUnit = other._weightUnit;
     _trustBLETime = other._trustBLETime;
+    _showBLETimeTrustDialog = other._showBLETimeTrustDialog;
     notifyListeners();
   }
 
@@ -455,6 +460,15 @@ class Settings extends ChangeNotifier {
   bool get trustBLETime => _trustBLETime;
   set trustBLETime(bool value) {
     _trustBLETime = value;
+    notifyListeners();
+  }
+
+  bool _showBLETimeTrustDialog = true;
+  /// Whether to warn the user when the time the bluetooth device reports is far
+  /// in the past and [trustBLETime] is true.
+  bool get showBLETimeTrustDialog => _showBLETimeTrustDialog;
+  set showBLETimeTrustDialog(bool value) {
+    _showBLETimeTrustDialog = value;
     notifyListeners();
   }
 // When adding fields notice the checklist at the top.

--- a/app/lib/screens/settings_screen.dart
+++ b/app/lib/screens/settings_screen.dart
@@ -319,6 +319,14 @@ class SettingsPage extends StatelessWidget {
                     if (value != null) settings.weightUnit = value;
                   },
                 ),
+              SwitchListTile(
+                value: settings.trustBLETime,
+                title: Text(localizations.trustBLETime),
+                secondary: const Icon(Icons.lock_clock_outlined),
+                onChanged: (value) {
+                  settings.trustBLETime = value;
+                },
+              ),
             ],),
             TitledColumn(
               title: Text(localizations.data),

--- a/app/test/features/input/forms/add_entry_form_test.dart
+++ b/app/test/features/input/forms/add_entry_form_test.dart
@@ -531,6 +531,41 @@ void main() {
     await tester.tap(find.text(localizations.btnConfirm));
     await tester.pumpAndSettle();
     expect(find.byType(AlertDialog), findsNothing);
+
+    // reopens the next time
+    await tester.tap(find.text('mockBleInput'));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsOneWidget);
+  });
+
+  testWidgets('allows disabling warning if time from ble is too old', (tester) async {
+    final localizations = await AppLocalizations.delegate.load(const Locale('en'));
+    await tester.pumpWidget(materialApp(AddEntryForm(
+      mockBleInput: (callback) => ListTile(
+        onTap: () => callback(mockRecord(time: DateTime(2000))),
+        title: Text('mockBleInput'),
+      ),
+    ),
+      settings: Settings(
+        bleInput: BluetoothInputMode.disabled,
+        trustBLETime: true,
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsNothing);
+    await tester.tap(find.text('mockBleInput'));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsOneWidget);
+    expect(find.textContaining('The bluetooth device reported a time off by'), findsOneWidget);
+    expect(find.text(localizations.dontShowAgain), findsOneWidget);
+
+    await tester.tap(find.text(localizations.dontShowAgain));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsNothing);
+    await tester.tap(find.text('mockBleInput'));
+    await tester.pumpAndSettle();
+    expect(find.byType(AlertDialog), findsNothing);
   });
 }
 


### PR DESCRIPTION
Implements #410:

- allows using phone time instead of bluetooth time via setting
- show a warning when the phone and ble time where more than 5 hours apart