### PR TITLE
Stop precomputing most recent range

### DIFF
--- a/app/lib/features/data_picker/interval_picker.dart
+++ b/app/lib/features/data_picker/interval_picker.dart
@@ -1,8 +1,8 @@
 import 'package:blood_pressure_app/features/data_picker/filter_button.dart';
 import 'package:blood_pressure_app/l10n/app_localizations.dart';
-import 'package:blood_pressure_app/model/datarange_extension.dart';
 import 'package:blood_pressure_app/model/storage/interval_store.dart';
 import 'package:flutter/material.dart';
+import 'package:health_data_store/health_data_store.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:week_of_year/date_week_extensions.dart';
@@ -66,10 +66,10 @@ class IntervalPicker extends StatelessWidget {
                       );
                       if (res != null) {
                         interval.changeStepSize(value!);
-                        final dateRange = res.dateRange.copyWith(
+                        interval.customRange = DateRange(
+                          start: res.start.copyWith(hour: 0, minute: 0, second: 0),
                           end: res.end.copyWith(hour: 23, minute: 59, second: 59),
                         );
-                        interval.currentRange = dateRange;
                       }
                     } else if (value != null) {
                       interval.changeStepSize(value);

--- a/app/lib/model/storage/interval_store.dart
+++ b/app/lib/model/storage/interval_store.dart
@@ -8,10 +8,22 @@ import 'package:health_data_store/health_data_store.dart';
 
 /// Class for storing the current interval, as it is needed in start page, statistics and export.
 class IntervalStorage extends ChangeNotifier {
+  /// Create a storage to interact with a display intervall.
+  IntervalStorage({
+    TimeStep stepSize = TimeStep.last7Days,
+    int directionalStep = 0,
+    DateRange? customRange,
+    TimeRange? timeRange,
+  }) : _stepSize = stepSize,
+       _directionalStep = directionalStep,
+       _customRange = customRange,
+       _timeRange = timeRange;
+
   /// Create a instance from a map created by [toMap].
   factory IntervalStorage.fromMap(Map<String, dynamic> map) => IntervalStorage(
     stepSize: TimeStep.deserialize(map['stepSize']),
-    range: ConvertUtil.parseRange(map['start'], map['end']),
+    directionalStep: ConvertUtil.parseInt(map['directionalStep']) ?? 0,
+    customRange: ConvertUtil.parseRange(map['customRangeStart'], map['customRangeEnd']),
     timeRange: TimeRange.fromJson(map['timeRange'] as Map<String, dynamic>?)
   );
 
@@ -24,34 +36,35 @@ class IntervalStorage extends ChangeNotifier {
     }
   }
 
-  /// Create a storage to interact with a display intervall.
-  IntervalStorage({TimeStep? stepSize, DateRange? range, TimeRange? timeRange}) :
-    _stepSize = stepSize ?? TimeStep.last7Days {
-    _currentRange = range ?? _getMostRecentDisplayIntervall();
-    _timeRange = timeRange;
-  }
-
-  TimeStep _stepSize;
-
-  late DateRange _currentRange;
-
-  TimeRange? _timeRange;
-
   /// Serialize the object to a restoreable map.
   Map<String, dynamic> toMap() => <String, dynamic>{
     'stepSize': stepSize.serialize(),
-    'start': currentRange.start.millisecondsSinceEpoch,
-    'end': currentRange.end.millisecondsSinceEpoch,
+    'directionalStep': _directionalStep,
+    'customRangeStart': _customRange?.start.millisecondsSinceEpoch,
+    'customRangeEnd': _customRange?.end.millisecondsSinceEpoch,
     'timeRange': _timeRange?.toJson(),
   };
 
   /// Serialize the object to a restoreable string.
   String toJson() => jsonEncode(toMap());
 
+  TimeStep _stepSize;
+
+  DateRange? _customRange;
+
+  int _directionalStep = 0;
+
+  TimeRange? _timeRange;
+
+  /// The range to use if [stepSize] is [TimeStep.custom]
+  set customRange(DateRange newRange) {
+    _customRange = newRange;
+    notifyListeners();
+  }
+
   /// The stepSize gets set through the changeStepSize method.
   TimeStep get stepSize => _stepSize;
 
-  // TODO: programmatically ensure this is respected:
   /// The [TimeRange] used to limit data selection if non-null.
   ///
   /// Data points must fall on or between the start and end times to be selected.
@@ -64,58 +77,56 @@ class IntervalStorage extends ChangeNotifier {
 
   /// sets the stepSize to the new value and resets the currentRange to the most recent one. 
   void changeStepSize(TimeStep value) {
+    _directionalStep = 0;
+    if (value == TimeStep.custom) _customRange ??= currentRange;
     _stepSize = value;
-    setToMostRecentInterval();
-  }
-
-  DateRange get currentRange => _currentRange;
-
-  set currentRange(DateRange value) {
-    _currentRange = value;
     notifyListeners();
   }
 
-  /// Sets internal _currentRange to the most recent intervall and notifies listeners.
-  void setToMostRecentInterval() {
-    _currentRange = _getMostRecentDisplayIntervall();
-    notifyListeners();
-  }
-
-  void moveDataRangeByStep(int directionalStep) {
-    final oldStart = currentRange.start;
-    final oldEnd = currentRange.end;
-    currentRange = switch (stepSize) {
+  DateRange get currentRange {
+    final range = _getMostRecentDisplayIntervall();
+    final oldStart = range.start;
+    final oldEnd = range.end;
+    return switch (stepSize) {
       TimeStep.day => DateRange(
-        start: oldStart.copyWith(day: oldStart.day + directionalStep),
-        end: oldEnd.copyWith(day: oldEnd.day + directionalStep),
+        start: oldStart.copyWith(day: oldStart.day + _directionalStep),
+        end: oldEnd.copyWith(day: oldEnd.day + _directionalStep),
       ),
       TimeStep.week || TimeStep.last7Days => DateRange(
-        start: oldStart.copyWith(day: oldStart.day + 7 * directionalStep),
-        end: oldEnd.copyWith(day: oldEnd.day + 7 * directionalStep),
+        start: oldStart.copyWith(day: oldStart.day + 7 * _directionalStep),
+        end: oldEnd.copyWith(day: oldEnd.day + 7 * _directionalStep),
       ),
       TimeStep.month => DateRange(
         // No fitting Duration: wraps correctly according to doc
-        start: oldStart.copyWith(month: oldStart.month + directionalStep),
-        end: oldEnd.copyWith(month: oldEnd.month + directionalStep),
+        start: oldStart.copyWith(month: oldStart.month + _directionalStep),
+        end: oldEnd.copyWith(month: oldEnd.month + _directionalStep),
       ),
       TimeStep.year => DateRange(
         // No fitting Duration: wraps correctly according to doc
-        start: oldStart.copyWith(year: oldStart.year + directionalStep),
-        end: oldEnd.copyWith(year: oldEnd.year + directionalStep),
+        start: oldStart.copyWith(year: oldStart.year + _directionalStep),
+        end: oldEnd.copyWith(year: oldEnd.year + _directionalStep),
       ),
-      TimeStep.lifetime => DateRange(
-        start: DateTime.fromMillisecondsSinceEpoch(1),
-        end: DateTime.now().copyWith(hour: 23, minute: 59, second: 59),
-      ),
+      TimeStep.lifetime => DateRange.all(),
       TimeStep.last30Days => DateRange(
-        start: oldStart.copyWith(day: oldStart.day + 30 * directionalStep),
-        end: oldEnd.copyWith(day: oldEnd.day + 30 * directionalStep),
+        start: oldStart.copyWith(day: oldStart.day + 30 * _directionalStep),
+        end: oldEnd.copyWith(day: oldEnd.day + 30 * _directionalStep),
       ),
       TimeStep.custom => DateRange(
-        start: oldStart.add(oldEnd.difference(oldStart) * directionalStep),
-        end: oldEnd.add(oldEnd.difference(oldStart) * directionalStep),
+        start: oldStart.add(oldEnd.difference(oldStart) * _directionalStep),
+        end: oldEnd.add(oldEnd.difference(oldStart) * _directionalStep),
       ),
     };
+  }
+
+  /// Resets any steps the user might have made.
+  void setToMostRecentInterval() {
+    _directionalStep = 0;
+    notifyListeners();
+  }
+
+  void moveDataRangeByStep(int delta) {
+    _directionalStep += delta;
+    notifyListeners();
   }
 
   DateRange _getMostRecentDisplayIntervall() {
@@ -146,10 +157,9 @@ class IntervalStorage extends ChangeNotifier {
         final endOfToday = now.copyWith(hour: 23, minute: 59, second: 59);
         return DateRange(start: start, end: endOfToday);
       case TimeStep.custom:
-        return DateRange(
-          start: now.subtract(currentRange.duration),
-          end: now,
-        );
+        // Do nothing
+        assert(_customRange != null);
+        return _customRange ?? DateRange.all();
     }
   }
 }

--- a/app/lib/screens/add_entry_screen.dart
+++ b/app/lib/screens/add_entry_screen.dart
@@ -39,12 +39,6 @@ class AddEntryScreen extends StatelessWidget {
         if (entry.intake != null) await intakeRepo.add(entry.intake!);
         if (entry.weight != null) await weightRepo.add(entry.weight!);
 
-        /*
-        read<IntervalStoreManager>().mainPage.setToMostRecentInterval();
-        read<IntervalStoreManager>().statsPage.setToMostRecentInterval();
-        read<IntervalStoreManager>().exportPage.setToMostRecentInterval();
-        */
-
         if (context.mounted &&
             context.read<ExportSettings>().exportAfterEveryEntry) {
           performExport(context, false);

--- a/app/test/data_util/interval_picker_test.dart
+++ b/app/test/data_util/interval_picker_test.dart
@@ -26,7 +26,7 @@ void main() {
   testWidgets('shows custom intervall start and end', (tester) async {
     final s = IntervalStoreManager(IntervalStorage(),IntervalStorage(),IntervalStorage());
     s.mainPage.changeStepSize(TimeStep.custom);
-    s.mainPage.currentRange = DateRange(start: DateTime(2000), end: DateTime(2001));
+    s.mainPage.customRange = DateRange(start: DateTime(2000), end: DateTime(2001));
 
     await tester.pumpWidget(materialApp(ChangeNotifierProvider.value(
       value: s,

--- a/app/test/model/intervall_store_test.dart
+++ b/app/test/model/intervall_store_test.dart
@@ -5,12 +5,12 @@ import 'package:health_data_store/health_data_store.dart';
 
 void main() {
   test('base constructor should initialize with values', () {
-    final storageObject = IntervalStorage(stepSize: TimeStep.month, range: DateRange(
+    final storageObject = IntervalStorage(stepSize: TimeStep.custom, customRange: DateRange(
         start: DateTime.fromMillisecondsSinceEpoch(1234),
         end: DateTime.fromMillisecondsSinceEpoch(5678),
     ),);
 
-    expect(storageObject.stepSize, TimeStep.month);
+    expect(storageObject.stepSize, TimeStep.custom);
     expect(storageObject.currentRange.start.millisecondsSinceEpoch, 1234);
     expect(storageObject.currentRange.end.millisecondsSinceEpoch, 5678);
   });
@@ -26,7 +26,7 @@ void main() {
   test('base constructor should initialize with only incomplete parameters', () {
     // only tests for no crashes
     IntervalStorage(stepSize: TimeStep.last30Days);
-    IntervalStorage(range: DateRange(
+    IntervalStorage(customRange: DateRange(
         start: DateTime.fromMillisecondsSinceEpoch(1234),
         end: DateTime.fromMillisecondsSinceEpoch(5678),
     ),);
@@ -56,7 +56,7 @@ void main() {
     final yearIntervall = IntervalStorage(stepSize: TimeStep.year);
     final last7DaysIntervall = IntervalStorage(stepSize: TimeStep.last7Days);
     final last30DaysIntervall = IntervalStorage(stepSize: TimeStep.last30Days);
-    final customIntervall = IntervalStorage(stepSize: TimeStep.custom, range: DateRange(
+    final customIntervall = IntervalStorage(stepSize: TimeStep.custom, customRange: DateRange(
         start: DateTime.fromMillisecondsSinceEpoch(1234),
         end: DateTime.fromMillisecondsSinceEpoch(1234 + 24 * 60 * 60 * 1000), // one day
     ),);
@@ -96,4 +96,15 @@ void main() {
     expect(customIntervall.currentRange.duration.inMilliseconds, 24 * 60 * 60 * 1000);
   });
 
+  test('switch behaves like expected', () {
+    bool success = false;
+    switch(TimeStep.last7Days) {
+      case TimeStep.lifetime:
+      case TimeStep.last7Days:
+      case TimeStep.last30Days:
+        success = true;
+      default:
+    }
+    expect(success, isTrue);
+  });
 }

--- a/app/test/model/intervall_store_test.dart
+++ b/app/test/model/intervall_store_test.dart
@@ -95,16 +95,4 @@ void main() {
     expect(last30DaysIntervall.currentRange.duration.inDays, 30);
     expect(customIntervall.currentRange.duration.inMilliseconds, 24 * 60 * 60 * 1000);
   });
-
-  test('switch behaves like expected', () {
-    bool success = false;
-    switch(TimeStep.last7Days) {
-      case TimeStep.lifetime:
-      case TimeStep.last7Days:
-      case TimeStep.last30Days:
-        success = true;
-      default:
-    }
-    expect(success, isTrue);
-  });
 }

--- a/app/test/model/json_serialization_test.dart
+++ b/app/test/model/json_serialization_test.dart
@@ -25,21 +25,21 @@ void main() {
       final recreatedData = IntervalStorage.fromJson(json);
 
       expect(initialData.stepSize, recreatedData.stepSize);
-      expect(initialData.currentRange.start.millisecondsSinceEpoch,
-          recreatedData.currentRange.start.millisecondsSinceEpoch,);
-      expect(initialData.currentRange.end.millisecondsSinceEpoch,
-          recreatedData.currentRange.end.millisecondsSinceEpoch,);
+      expect(initialData.currentRange.start.day,
+          recreatedData.currentRange.start.day);
+      expect(initialData.currentRange.end.day,
+          recreatedData.currentRange.end.day);
     });
 
     test('should load same data from json in edge cases', () {
-      final initialData = IntervalStorage(stepSize: TimeStep.month, range: DateRange(
+      final initialData = IntervalStorage(stepSize: TimeStep.custom, customRange: DateRange(
           start: DateTime.fromMillisecondsSinceEpoch(1234),
           end: DateTime.fromMillisecondsSinceEpoch(5678),
       ),);
       final json = initialData.toJson();
       final recreatedData = IntervalStorage.fromJson(json);
 
-      expect(initialData.stepSize, TimeStep.month);
+      expect(initialData.stepSize, TimeStep.custom);
       expect(recreatedData.currentRange.start.millisecondsSinceEpoch, 1234);
       expect(recreatedData.currentRange.end.millisecondsSinceEpoch, 5678);
     });

--- a/health_data_store/lib/src/types/date_range.dart
+++ b/health_data_store/lib/src/types/date_range.dart
@@ -25,9 +25,9 @@ abstract class DateRange with _$DateRange {
 
   /// Creates a date range from unix epoch to now.
   factory DateRange.all() => DateRange(
-        start: DateTime.fromMillisecondsSinceEpoch(0),
-        end: DateTime.now(),
-      );
+    start: DateTime.fromMillisecondsSinceEpoch(0),
+    end: DateTime.now().copyWith(hour: 23, minute: 59, second: 59),
+  );
 
   /// Returns a [Duration] of the time between [start] and [end].
   ///

--- a/health_data_store/lib/src/types/date_range.dart
+++ b/health_data_store/lib/src/types/date_range.dart
@@ -25,9 +25,9 @@ abstract class DateRange with _$DateRange {
 
   /// Creates a date range from unix epoch to now.
   factory DateRange.all() => DateRange(
-    start: DateTime.fromMillisecondsSinceEpoch(0),
-    end: DateTime.now().copyWith(hour: 23, minute: 59, second: 59),
-  );
+        start: DateTime.fromMillisecondsSinceEpoch(0),
+        end: DateTime.now().copyWith(hour: 23, minute: 59, second: 59),
+      );
 
   /// Returns a [Duration] of the time between [start] and [end].
   ///


### PR DESCRIPTION
From now on we store the offset and compute ranges when they are needed. Users will need to set custom ranges and offsets manually after updating.

closes #668

Probably also closes #657, but I was unable to reproduce the issue.