### PR TITLE
Add support for proprietary microlife protocol. Add a button for importing all measurements

### DIFF
--- a/app/lib/features/bluetooth/bluetooth_input.dart
+++ b/app/lib/features/bluetooth/bluetooth_input.dart
@@ -26,6 +26,7 @@ class BluetoothInput extends StatefulWidget {
   /// Create a measurement input through bluetooth.
   const BluetoothInput({super.key,
     required this.onMeasurement,
+    required this.onAllMeasurements,
     required this.manager,
     this.bluetoothCubit,
     this.deviceScanCubit,
@@ -37,6 +38,9 @@ class BluetoothInput extends StatefulWidget {
 
   /// Called when a measurement was received through bluetooth.
   final void Function(BloodPressureRecord data) onMeasurement;
+
+  /// Called when the user chooses to import all received measurements through bluetooth.
+  final void Function(List<BloodPressureRecord> data) onAllMeasurements;
 
   /// Function to customize [BluetoothCubit] creation.
   final BluetoothCubit Function()? bluetoothCubit;
@@ -217,6 +221,12 @@ class _BluetoothInputState extends State<BluetoothInput> with TypeLogger {
           BleReadMultiple() => MeasurementMultiple(
             onClosed: _returnToIdle,
             onSelect: (data) => _deviceReadCubit!.useMeasurement(data),
+            onSelectAll: (data) {
+              widget.onAllMeasurements(
+                data.map((e) => e.asBloodPressureRecord()).toList(),
+              );
+              _returnToIdle();
+            },
             measurements: state.data,
           ),
           BleReadSuccess() => MeasurementSuccess(

--- a/app/lib/features/bluetooth/logic/ble_read_cubit.dart
+++ b/app/lib/features/bluetooth/logic/ble_read_cubit.dart
@@ -1,6 +1,9 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:blood_pressure_app/features/bluetooth/logic/characteristics/ble_measurement_data.dart';
+import 'package:blood_pressure_app/features/bluetooth/logic/characteristics/microlife_measurement_data.dart';
+import 'package:blood_pressure_app/features/bluetooth/logic/characteristics/microlife_protocol.dart';
 import 'package:blood_pressure_app/features/bluetooth/logic/characteristics/yonker_measurement_data.dart';
 import 'package:blood_pressure_app/logging.dart';
 import 'package:bluetooth_low_energy/bluetooth_low_energy.dart';
@@ -28,6 +31,17 @@ class BleReadCubit extends Cubit<BleReadState> with TypeLogger {
 
   static const yonkerServiceUUID = 'cdeacd80-5235-4c07-8846-93a37ee6b86d';
   static const yonkerCharacteristicUUID = 'cdeacd81-5235-4c07-8846-93a37ee6b86d';
+
+  static const microlifeServiceUUID = 'fff0';
+  static const microlifeNotifyCharacteristicUUID = 'fff1';
+  static const microlifeWriteCharacteristicUUID = 'fff2';
+
+  /// Maximum number of bytes to be written to the device in a single GATT write.
+  static const _microlifeWriteChunkSize = 20;
+
+  static const _microlifeResponseTimeout = Duration(seconds: 30);
+  final List<int> _microlifeResponseByteBuffer = [];
+  Completer<Uint8List>? _microlifePendingResponse;
 
   Future<bool> _connectDevice() async {
     logger.info('Connecting to ${device.uuid}');
@@ -64,6 +78,11 @@ class BleReadCubit extends Cubit<BleReadState> with TypeLogger {
             (s) => s.uuid == UUID.fromString(yonkerServiceUUID));
     if (yonkerService != null) return _readYonker(yonkerService);
     logger.finest("didn't get yonker service");
+
+    final microlifeService = services.firstWhereOrNull(
+            (s) => s.uuid == UUID.fromString(microlifeServiceUUID));
+    if (microlifeService != null) return _readMicrolife(microlifeService);
+    logger.finest("didn't get microlife service");
 
     emit(BleReadFailure('Device ${device.uuid} does not advertise a supported service'));
   }
@@ -171,6 +190,149 @@ class BleReadCubit extends Cubit<BleReadState> with TypeLogger {
       return;
     }
     emit(BleReadSuccess(data));
+  }
+
+  /// This reads stored measurements from a Microlife blood pressure monitor
+  /// (e.g. BP3GY1-2N), which uses a vendor specific protocol on the `fff0`
+  /// service instead of the standard GATT blood pressure service.
+  ///
+  /// The process is as follows:
+  /// 1. subscribe to notifications on `fff1` (responses can possibly be split across multiple packets)
+  /// 2. set the device clock by writing to `fff2`
+  /// 3. request all stored measurements
+  /// 4. ask the device to disconnect
+  Future<void> _readMicrolife(GATTService service) async {
+    logger.finest('_readMicrolife()');
+    final notifyCharacteristic = service.characteristics.firstWhereOrNull(
+            (c) => c.uuid == UUID.fromString(microlifeNotifyCharacteristicUUID));
+    final writeCharacteristic = service.characteristics.firstWhereOrNull(
+            (c) => c.uuid == UUID.fromString(microlifeWriteCharacteristicUUID));
+
+    if (notifyCharacteristic == null || writeCharacteristic == null) {
+      emit(BleReadFailure('Device ${device.uuid} does not provide the expected microlife characteristics'));
+      return;
+    }
+
+    _microlifeResponseByteBuffer.clear();
+    _microlifePendingResponse = null;
+    final subscription = cm.characteristicNotified
+        .where((e) => e.characteristic == notifyCharacteristic && e.peripheral == device)
+        .listen((e) => _onMicrolifeNotified(e.value));
+
+    try {
+      await cm.setCharacteristicNotifyState(device, notifyCharacteristic, state: true);
+
+      // Keep the device clock accurate for future measurements.
+      try {
+        await _sendMicrolifeCommand(writeCharacteristic,
+            MicrolifeProtocol.buildSetTimeCommand(DateTime.now()),
+            timeout: const Duration(seconds: 10));
+      } catch (e) {
+        logger.warning('Microlife set time failed, continuing: $e');
+      }
+
+      final payload = await _sendMicrolifeCommand(
+          writeCharacteristic, MicrolifeProtocol.getMeasurementsCommand);
+      final measurements = MicrolifeMeasurementData.decodeMeasurements(payload)
+          .map((m) => m.asBleData)
+          .toList();
+
+      // Politely tell the device to disconnect (no response is sent).
+      try {
+        await _sendMicrolifeCommand(
+            writeCharacteristic, MicrolifeProtocol.disconnectCommand,
+            waitForResponse: false);
+      } catch (e) {
+        logger.finer('Microlife disconnect command failed: $e');
+      }
+
+      if (measurements.isEmpty) {
+        emit(BleReadFailure('No data received'));
+      } else if (measurements.length == 1) {
+        emit(BleReadSuccess(measurements.first));
+      } else {
+        emit(BleReadMultiple(measurements));
+      }
+    } on TimeoutException {
+      logger.warning('Microlife communication timed out for ${device.uuid}');
+      emit(BleReadFailure('No data received'));
+    } catch (e) {
+      logger.warning('Microlife communication failed: $e');
+      emit(BleReadFailure('Could not decode data'));
+    } finally {
+      await subscription.cancel();
+      try {
+        await cm.setCharacteristicNotifyState(device, notifyCharacteristic, state: false);
+      } catch (e) {
+        logger.finer('Failed to disable microlife notifications: $e');
+      }
+      _microlifePendingResponse = null;
+      _microlifeResponseByteBuffer.clear();
+    }
+  }
+
+  /// Reassembles Microlife response frames from one or more notifications and
+  /// completes the [_microlifePendingResponse] once a full frame is received.
+  void _onMicrolifeNotified(Uint8List value) {
+    logger.fine('Microlife notification: $value');
+    _microlifeResponseByteBuffer.addAll(value);
+
+    final expectedLength = MicrolifeProtocol.expectedFrameLength(_microlifeResponseByteBuffer);
+    if (expectedLength == null || _microlifeResponseByteBuffer.length < expectedLength) {
+      return; // wait for the remaining packets
+    }
+
+    final frame = _microlifeResponseByteBuffer.sublist(0, expectedLength);
+    _microlifeResponseByteBuffer.clear();
+
+    final pending = _microlifePendingResponse;
+    if (pending == null || pending.isCompleted) return;
+
+    final payload = MicrolifeProtocol.parseResponsePayload(frame);
+    if (payload == null) {
+      pending.completeError(StateError('Invalid microlife frame: $frame'));
+    } else {
+      pending.complete(payload);
+    }
+  }
+
+  /// Writes [command] to the Microlife write characteristic (in chunks) and,
+  /// when [waitForResponse] is true, waits for the decoded response payload.
+  Future<Uint8List> _sendMicrolifeCommand(
+    GATTCharacteristic writeChar,
+    List<int> command, {
+    bool waitForResponse = true,
+    Duration timeout = _microlifeResponseTimeout,
+  }) async {
+    _microlifeResponseByteBuffer.clear();
+    Completer<Uint8List>? completer;
+    if (waitForResponse) {
+      completer = Completer<Uint8List>();
+      _microlifePendingResponse = completer;
+    }
+
+    final writeType = writeChar.properties.contains(GATTCharacteristicProperty.write)
+        ? GATTCharacteristicWriteType.withResponse
+        : GATTCharacteristicWriteType.withoutResponse;
+
+    for (var offset = 0; offset < command.length; offset += _microlifeWriteChunkSize) {
+      final end = min(offset + _microlifeWriteChunkSize, command.length);
+      await cm.writeCharacteristic(
+        device,
+        writeChar,
+        value: Uint8List.fromList(command.sublist(offset, end)),
+        type: writeType,
+      );
+    }
+
+    if (completer == null) return Uint8List(0);
+    try {
+      return await completer.future.timeout(timeout);
+    } finally {
+      if (identical(_microlifePendingResponse, completer)) {
+        _microlifePendingResponse = null;
+      }
+    }
   }
 
   @mustCallSuper

--- a/app/lib/features/bluetooth/logic/characteristics/microlife_measurement_data.dart
+++ b/app/lib/features/bluetooth/logic/characteristics/microlife_measurement_data.dart
@@ -1,0 +1,78 @@
+import 'dart:typed_data';
+
+import 'package:blood_pressure_app/features/bluetooth/logic/characteristics/ble_measurement_data.dart';
+import 'package:blood_pressure_app/logging.dart';
+
+/// A single measurement decoded from a Microlife bluetooth blood pressure
+/// monitor (e.g. BP3GY1-2N).
+class MicrolifeMeasurementData {
+  
+  MicrolifeMeasurementData({
+    required this.timestamp,
+    required this.systolicMmHg,
+    required this.diastolicMmHg,
+    required this.pulseBpm,
+  });
+
+  // Minute-accurate timestamp
+  final DateTime timestamp;
+
+  final int systolicMmHg;
+  final int diastolicMmHg;
+  final int pulseBpm;
+
+  // Offset of the first measurement record in the response payload.
+  static const _recordsOffset = 38;
+
+  // Distance in bytes between two measurement records. Only the first 8 bytes
+  // of each record are used, the remaining bytes are padding.
+  static const _recordStride = 10;
+
+  /// Decode all measurements contained in a "get measurements" response payload.
+  ///
+  /// [payload] is the content of a protocol frame without the
+  /// header, length and checksum (see `MicrolifeProtocol`).
+  ///
+  /// Each record stores single byte values without scaling:
+  /// `systolic, diastolic, pulse, year (+2000), month, day, hour, minute`.
+  static List<MicrolifeMeasurementData> decodeMeasurements(Uint8List payload) {
+    final measurements = <MicrolifeMeasurementData>[];
+    for (var i = _recordsOffset; i + 8 <= payload.length; i += _recordStride) {
+      final systolic = payload[i];
+      final diastolic = payload[i + 1];
+      final pulse = payload[i + 2];
+      final year = 2000 + payload[i + 3];
+      final month = payload[i + 4];
+      final day = payload[i + 5];
+      final hour = payload[i + 6];
+      final minute = payload[i + 7];
+
+      // Empty record slots are returned as zeros, skip them.
+      if (systolic == 0 && diastolic == 0 && pulse == 0) continue;
+
+      if (month < 1 || month > 12 || day < 1 || day > 31
+          || hour > 23 || minute > 59) {
+        log.info('MicrolifeMeasurementData skipping record with invalid date: '
+            '${payload.sublist(i, i + 8)}');
+        continue;
+      }
+
+      measurements.add(MicrolifeMeasurementData(
+        timestamp: DateTime(year, month, day, hour, minute),
+        systolicMmHg: systolic,
+        diastolicMmHg: diastolic,
+        pulseBpm: pulse,
+      ));
+    }
+    return measurements;
+  }
+
+  BleMeasurementData get asBleData => BleMeasurementData(
+    timestamp: timestamp,
+    systolic: systolicMmHg.toDouble(),
+    diastolic: diastolicMmHg.toDouble(),
+    isMMHG: true,
+    pulse: pulseBpm.toDouble(),
+    meanArterialPressure: 1 / 3 * systolicMmHg + 2 / 3 * diastolicMmHg,
+  );
+}

--- a/app/lib/features/bluetooth/logic/characteristics/microlife_protocol.dart
+++ b/app/lib/features/bluetooth/logic/characteristics/microlife_protocol.dart
@@ -1,0 +1,68 @@
+import 'dart:typed_data';
+
+import 'package:blood_pressure_app/logging.dart';
+
+/// Microlife monitors (e.g. the BP3GY1-2N) don't expose the standard bluetooth
+/// blood pressure service. Instead commands are written to `fff2` and responses
+/// are received as notifications on `fff1`. Both directions share the same frame
+/// layout:
+///
+/// ```
+/// byte 0..1  header     (command: 0x4D 0xFF, response: 0x4D 0x3A == "M:")
+/// byte 2..3  length     (big endian, payload length + checksum length)
+/// byte 4..n  payload
+/// byte n+1   checksum   (least significant byte of the sum of all preceding bytes)
+/// ```
+///
+/// The protocol was reverse engineered from the Microlife Connect android app,
+/// ported here from the python implementation `bpm_bt.py`
+/// (https://github.com/joergmlpts/blood-pressure-monitor).
+class MicrolifeProtocol {
+  MicrolifeProtocol._();
+
+  static const responseHeader = [0x4D, 0x3A];
+  static const List<int> getMeasurementsCommand = [77, 255, 0, 9, 0, 0, 0, 0, 0, 0, 0, 253, 82];
+  static const List<int> disconnectCommand = [77, 255, 0, 2, 4, 82];
+
+  static int checksum(Iterable<int> bytes) =>
+      bytes.fold<int>(0, (sum, b) => sum + b) % 256;
+
+  static List<int> buildSetTimeCommand(DateTime time) {
+    final command = <int>[
+      77, 255, 0, 8, 13,
+      time.year - 2000,
+      time.month,
+      time.day,
+      time.hour,
+      time.minute,
+      time.second,
+    ];
+    return [...command, checksum(command)];
+  }
+
+  /// Total length of the frame described by [buffer]
+  static int? expectedFrameLength(List<int> buffer) {
+    if (buffer.length < 4) return null;
+    return (buffer[2] << 8) + buffer[3] + 4;
+  }
+
+  static Uint8List? parseResponsePayload(List<int> frame) {
+    if (frame.length < 5) {
+      log.warning('MicrolifeProtocol received frame that is too short: $frame');
+      return null;
+    }
+    if (frame[0] != responseHeader[0] || frame[1] != responseHeader[1]) {
+      log.warning("MicrolifeProtocol didn't find response header: $frame");
+      return null;
+    }
+    if (frame.length != expectedFrameLength(frame)) {
+      log.warning('MicrolifeProtocol frame length mismatch: $frame');
+      return null;
+    }
+    if (checksum(frame.sublist(0, frame.length - 1)) != frame.last) {
+      log.warning('MicrolifeProtocol checksum mismatch: $frame');
+      return null;
+    }
+    return Uint8List.fromList(frame.sublist(4, frame.length - 1));
+  }
+}

--- a/app/lib/features/bluetooth/ui/measurement_multiple.dart
+++ b/app/lib/features/bluetooth/ui/measurement_multiple.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'package:blood_pressure_app/features/bluetooth/logic/characteristics/ble_measurement_data.dart';
 import 'package:blood_pressure_app/features/bluetooth/ui/input_card.dart';
 import 'package:blood_pressure_app/l10n/app_localizations.dart';
@@ -91,16 +92,13 @@ class MeasurementMultiple extends StatelessWidget {
             ),
           ),
           ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 300),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxHeight: 300),
-              child: ListView(
-                shrinkWrap: true,
-                children: [
-                  for (final (index, data) in measurements.indexed)
-                    _buildMeasurementTile(context, index, data),
-                ]
-              ),
+            constraints: BoxConstraints(maxHeight: min(400.0, MediaQuery.of(context).size.height)),
+            child: ListView(
+              shrinkWrap: true,
+              children: [
+                for (final (index, data) in measurements.indexed)
+                  _buildMeasurementTile(context, index, data),
+              ]
             ),
           ),
         ],

--- a/app/lib/features/bluetooth/ui/measurement_multiple.dart
+++ b/app/lib/features/bluetooth/ui/measurement_multiple.dart
@@ -5,12 +5,12 @@ import 'package:flutter/material.dart';
 
 /// Indication of a successful bluetooth read that returned multiple measurements.
 ///
-/// TODO: Some devices can store up to 100 measurements which could cause a very long ListView. Maybe optimize UI for that?
 class MeasurementMultiple extends StatelessWidget {
   /// Indicate a successful read while taking a bluetooth measurement.
   const MeasurementMultiple({super.key,
     required this.onClosed,
     required this.onSelect,
+    required this.onSelectAll,
     required this.measurements,
   });
 
@@ -22,6 +22,9 @@ class MeasurementMultiple extends StatelessWidget {
 
   /// Called when user selects a measurement
   final void Function(BleMeasurementData data) onSelect;
+
+  /// Called when the user chooses to import every measurement at once.
+  final void Function(List<BleMeasurementData> data) onSelectAll;
   
   Widget _buildMeasurementTile(BuildContext context, int index, BleMeasurementData data) {
     final localizations = AppLocalizations.of(context)!;
@@ -69,15 +72,38 @@ class MeasurementMultiple extends StatelessWidget {
       return aTimestamp > bTimestamp ? -1 : 1;
     });
 
+  final localizations = AppLocalizations.of(context)!;
   return InputCard(
       onClosed: onClosed,
-      title: Text(AppLocalizations.of(context)!.selectMeasurementTitle),
-      child: ListView(
-        shrinkWrap: true,
+      title: Text(localizations.selectMeasurementTitle),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
         children: [
-          for (final (index, data) in measurements.indexed)
-            _buildMeasurementTile(context, index, data),
-        ]
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: () => onSelectAll(measurements),
+                icon: const Icon(Icons.download),
+                label: Text(localizations.importAll(measurements.length)),
+              ),
+            ),
+          ),
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxHeight: 300),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 300),
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  for (final (index, data) in measurements.indexed)
+                    _buildMeasurementTile(context, index, data),
+                ]
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/app/lib/features/export_import/model/csv_converter.dart
+++ b/app/lib/features/export_import/model/csv_converter.dart
@@ -201,6 +201,7 @@ class CsvConverter with TypeLogger {
         intake: intakes?.firstOrNull,
         note: note,
         record: record,
+        records: null,
         weight: weight,
       ));
       if (intakes != null && intakes.length > 1) {
@@ -213,7 +214,7 @@ class CsvConverter with TypeLogger {
               medicine: intakes[i].medicine,
               dosis: intakes[i].dosis,
             ),
-            note: null, record: null, weight: null,
+            note: null, record: null, weight: null, records: null
           ));
         }
       }

--- a/app/lib/features/input/forms/add_entry_form.dart
+++ b/app/lib/features/input/forms/add_entry_form.dart
@@ -222,6 +222,7 @@ class AddEntryFormState extends FormStateBase<AddEntryFormValue, AddEntryForm>
       timestamp: time,
       note: note,
       record: record,
+      records: null,
       intake: intake,
       weight: weight,
     );
@@ -299,6 +300,7 @@ class AddEntryFormState extends FormStateBase<AddEntryFormValue, AddEntryForm>
           : _timeForm.currentState?.save() ?? DateTime.now(),
       note: null,
       record: record,
+      records: null,
       intake: null,
       weight: null,
     ));
@@ -307,24 +309,24 @@ class AddEntryFormState extends FormStateBase<AddEntryFormValue, AddEntryForm>
   /// Gets called on inputs from a bluetooth device or similar. (multiple records)
   Future<void> _onExternalMeasurements(List<BloodPressureRecord> records) async {
     if (records.isEmpty) return;
-    final localizations = AppLocalizations.of(context)!;
-    final repo = RepositoryProvider.of<BloodPressureRepository>(context);
-    final messenger = ScaffoldMessenger.of(context);
-    final navigator = Navigator.of(context);
-    final exportSettings = context.read<ExportSettings>();
 
-    for (final record in records) {
-      await repo.add(record);
-    }
     if (!mounted) return;
+
+    final messenger = ScaffoldMessenger.of(context);
+    final localizations = AppLocalizations.of(context)!;
 
     messenger.showSnackBar(SnackBar(
       content: Text(localizations.measurementsImported(records.length)),
     ));
-    if (exportSettings.exportAfterEveryEntry) {
-      performExport(context, false);
-    }
-    navigator.pop();
+
+    fillForm((
+      timestamp: DateTime.now(),
+      note: null,
+      record: null,
+      records: records,
+      intake: null,
+      weight: null,
+    ));
   }
 
   @override
@@ -401,6 +403,7 @@ typedef AddEntryFormValue = ({
   DateTime timestamp,
   Note? note,
   BloodPressureRecord? record,
+  List<BloodPressureRecord>? records,
   MedicineIntake? intake,
   BodyweightRecord? weight,
 });
@@ -411,6 +414,7 @@ class _AddEntryFormValueBuilder {
   DateTime timestamp;
   Note? note;
   BloodPressureRecord? record;
+  List<BloodPressureRecord>? records;
   MedicineIntake? intake;
   BodyweightRecord? weight;
 
@@ -418,6 +422,7 @@ class _AddEntryFormValueBuilder {
     timestamp: timestamp,
     note: note,
     record: record,
+    records: records,
     intake: intake,
     weight: weight,
   );

--- a/app/lib/features/input/forms/add_entry_form.dart
+++ b/app/lib/features/input/forms/add_entry_form.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:blood_pressure_app/features/bluetooth/backend/bluetooth_backend.dart';
 import 'package:blood_pressure_app/features/bluetooth/bluetooth_input.dart';
 import 'package:blood_pressure_app/features/bluetooth/logic/bluetooth_cubit.dart';
-import 'package:blood_pressure_app/features/export_import/export_button.dart';
+import 'package:blood_pressure_app/features/export_import/ui/export_button.dart';
 import 'package:blood_pressure_app/features/input/forms/blood_pressure_form.dart';
 import 'package:blood_pressure_app/features/input/forms/date_time_form.dart';
 import 'package:blood_pressure_app/features/input/forms/form_base.dart';

--- a/app/lib/features/input/forms/add_entry_form.dart
+++ b/app/lib/features/input/forms/add_entry_form.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:blood_pressure_app/features/bluetooth/backend/bluetooth_backend.dart';
 import 'package:blood_pressure_app/features/bluetooth/bluetooth_input.dart';
 import 'package:blood_pressure_app/features/bluetooth/logic/bluetooth_cubit.dart';
+import 'package:blood_pressure_app/features/export_import/export_button.dart';
 import 'package:blood_pressure_app/features/input/forms/blood_pressure_form.dart';
 import 'package:blood_pressure_app/features/input/forms/date_time_form.dart';
 import 'package:blood_pressure_app/features/input/forms/form_base.dart';
@@ -20,7 +21,6 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:health_data_store/health_data_store.dart';
-import 'package:provider/provider.dart';
 
 /// Primary form to enter all types of entries.
 class AddEntryForm extends FormBase<AddEntryFormValue> with TypeLogger {
@@ -304,6 +304,29 @@ class AddEntryFormState extends FormStateBase<AddEntryFormValue, AddEntryForm>
     ));
   }
 
+  /// Gets called on inputs from a bluetooth device or similar. (multiple records)
+  Future<void> _onExternalMeasurements(List<BloodPressureRecord> records) async {
+    if (records.isEmpty) return;
+    final localizations = AppLocalizations.of(context)!;
+    final repo = RepositoryProvider.of<BloodPressureRepository>(context);
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+    final exportSettings = context.read<ExportSettings>();
+
+    for (final record in records) {
+      await repo.add(record);
+    }
+    if (!mounted) return;
+
+    messenger.showSnackBar(SnackBar(
+      content: Text(localizations.measurementsImported(records.length)),
+    ));
+    if (exportSettings.exportAfterEveryEntry) {
+      performExport(context, false);
+    }
+    navigator.pop();
+  }
+
   @override
   Widget build(BuildContext context) {
     final settings = context.watch<Settings>();
@@ -320,6 +343,7 @@ class AddEntryFormState extends FormStateBase<AddEntryFormValue, AddEntryForm>
           BluetoothInputMode.newBluetoothInputCrossPlatform => BluetoothInput(
             manager: BluetoothManager.create(),
             onMeasurement: _onExternalMeasurement,
+            onAllMeasurements: _onExternalMeasurements,
             bluetoothCubit: widget.bluetoothCubit,
           ),
         })(),

--- a/app/lib/features/measurement_list/weight_list.dart
+++ b/app/lib/features/measurement_list/weight_list.dart
@@ -47,6 +47,7 @@ class WeightList extends StatelessWidget {
                     timestamp: records[idx].time,
                     note: null,
                     record: null,
+                    records: null,
                     intake: null,
                     weight: records[idx],
                   )),

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -343,6 +343,24 @@
   "@select": {
     "description": "Used when f.e. selecting a single measurement when the bluetooth device returned multiple"
   },
+  "importAll": "Import all ({count})",
+  "@importAll": {
+    "description": "Button to import every measurement returned by a bluetooth device.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "measurementsImported": "{count} measurements imported",
+  "@measurementsImported": {
+    "description": "Confirmation shown after importing all measurements returned by a bluetooth device.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
   "bloodPressure": "Blood pressure",
   "preferredWeightUnit": "Preferred weight unit",
   "@preferredWeightUnit": {

--- a/app/lib/screens/add_entry_screen.dart
+++ b/app/lib/screens/add_entry_screen.dart
@@ -35,6 +35,11 @@ class AddEntryScreen extends StatelessWidget {
         if (initialRecord?.weight != null) await weightRepo.remove(initialRecord!.weight!);
 
         if (entry.record != null) await recordRepo.add(entry.record!);
+        if (entry.records != null) {
+          for (final record in entry.records!) {
+            await recordRepo.add(record);
+          }
+        }
         if (entry.note != null) await noteRepo.add(entry.note!);
         if (entry.intake != null) await intakeRepo.add(entry.intake!);
         if (entry.weight != null) await weightRepo.add(entry.weight!);

--- a/app/test/features/bluetooth/bluetooth_input_test.dart
+++ b/app/test/features/bluetooth/bluetooth_input_test.dart
@@ -53,6 +53,7 @@ void main() {
     await tester.pumpWidget(materialApp(BluetoothInput(
       manager: MockBluetoothManager(),
       onMeasurement: reads.add,
+      onAllMeasurements: (_) {},
       bluetoothCubit: () => bluetoothCubit,
       deviceScanCubit: () => deviceScanCubit,
       bleReadCubit: () => bleReadCubit,
@@ -90,6 +91,7 @@ void main() {
     await tester.pumpWidget(materialApp(BluetoothInput(
       manager: MockBluetoothManager(),
       onMeasurement: reads.add,
+      onAllMeasurements: (_) {},
       bluetoothCubit: () => bluetoothCubit,
       deviceScanCubit: () => deviceScanCubit,
     )));
@@ -110,6 +112,7 @@ void main() {
     await tester.pumpWidget(materialApp(BluetoothInput(
       manager: MockBluetoothManager(),
       onMeasurement: (_) {},
+      onAllMeasurements: (_) {},
       bluetoothCubit: () => bluetoothCubit,
     )));
     expect(tester.takeException(), isNull);

--- a/app/test/features/bluetooth/logic/characteristics/microlife_measurement_data_test.dart
+++ b/app/test/features/bluetooth/logic/characteristics/microlife_measurement_data_test.dart
@@ -1,0 +1,70 @@
+import 'dart:typed_data';
+
+import 'package:blood_pressure_app/features/bluetooth/logic/characteristics/microlife_measurement_data.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  /// Builds a "get measurements" payload with [records] starting at the fixed
+  /// 38 byte offset the device uses.
+  Uint8List payloadWith(List<List<int>> records) => Uint8List.fromList([
+    ...List.filled(38, 0),
+    for (final record in records) ...record,
+  ]);
+
+  test('decodes multiple measurements', () {
+    final result = MicrolifeMeasurementData.decodeMeasurements(payloadWith([
+      [120, 80, 60, 24, 6, 15, 14, 30, 0, 0],
+      [130, 85, 70, 25, 1, 2, 3, 4, 0, 0],
+    ]));
+
+    expect(result, hasLength(2));
+
+    expect(result[0].systolicMmHg, 120);
+    expect(result[0].diastolicMmHg, 80);
+    expect(result[0].pulseBpm, 60);
+    expect(result[0].timestamp, DateTime(2024, 6, 15, 14, 30));
+
+    expect(result[1].systolicMmHg, 130);
+    expect(result[1].diastolicMmHg, 85);
+    expect(result[1].pulseBpm, 70);
+    expect(result[1].timestamp, DateTime(2025, 1, 2, 3, 4));
+  });
+
+  test('converts to BleMeasurementData', () {
+    final result = MicrolifeMeasurementData.decodeMeasurements(payloadWith([
+      [120, 80, 60, 24, 6, 15, 14, 30, 0, 0],
+    ]));
+
+    final ble = result.single.asBleData;
+    expect(ble.systolic, 120.0);
+    expect(ble.diastolic, 80.0);
+    expect(ble.pulse, 60.0);
+    expect(ble.isMMHG, true);
+    expect(ble.meanArterialPressure, closeTo(1 / 3 * 120 + 2 / 3 * 80, 0.001));
+    expect(ble.timestamp, DateTime(2024, 6, 15, 14, 30));
+  });
+
+  test('skips empty record slots', () {
+    final result = MicrolifeMeasurementData.decodeMeasurements(payloadWith([
+      [120, 80, 60, 24, 6, 15, 14, 30, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    ]));
+
+    expect(result, hasLength(1));
+    expect(result.single.systolicMmHg, 120);
+  });
+
+  test('skips records with invalid dates', () {
+    final result = MicrolifeMeasurementData.decodeMeasurements(payloadWith([
+      [110, 70, 65, 24, 0, 15, 14, 30, 0, 0], // month 0 is invalid
+    ]));
+
+    expect(result, isEmpty);
+  });
+
+  test('returns empty list when there are no records', () {
+    final result = MicrolifeMeasurementData.decodeMeasurements(
+        Uint8List.fromList(List.filled(38, 0)));
+    expect(result, isEmpty);
+  });
+}

--- a/app/test/features/bluetooth/logic/characteristics/microlife_protocol_test.dart
+++ b/app/test/features/bluetooth/logic/characteristics/microlife_protocol_test.dart
@@ -1,0 +1,57 @@
+import 'package:blood_pressure_app/features/bluetooth/logic/characteristics/microlife_protocol.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('computes checksum as least significant byte of sum', () {
+    expect(MicrolifeProtocol.checksum([77, 255, 0, 9, 0, 0, 0, 0, 0, 0, 0, 253]), 82);
+    expect(MicrolifeProtocol.checksum([]), 0);
+  });
+
+  test('predefined commands carry a valid checksum', () {
+    final getMeasurements = MicrolifeProtocol.getMeasurementsCommand;
+    expect(
+      MicrolifeProtocol.checksum(getMeasurements.sublist(0, getMeasurements.length - 1)),
+      getMeasurements.last,
+    );
+
+    final disconnect = MicrolifeProtocol.disconnectCommand;
+    expect(
+      MicrolifeProtocol.checksum(disconnect.sublist(0, disconnect.length - 1)),
+      disconnect.last,
+    );
+  });
+
+  test('builds a valid set time command', () {
+    final command = MicrolifeProtocol.buildSetTimeCommand(DateTime(2024, 6, 15, 14, 30, 45));
+
+    expect(command, [77, 255, 0, 8, 13, 24, 6, 15, 14, 30, 45, 231]);
+    expect(
+      MicrolifeProtocol.checksum(command.sublist(0, command.length - 1)),
+      command.last,
+    );
+  });
+
+  test('determines expected frame length once header is available', () {
+    expect(MicrolifeProtocol.expectedFrameLength([77, 58]), isNull);
+    expect(MicrolifeProtocol.expectedFrameLength([77, 58, 0, 2]), 6);
+    expect(MicrolifeProtocol.expectedFrameLength([77, 58, 1, 0]), 260);
+  });
+
+  test('parses a valid response payload', () {
+    // ack frame: header "M:", length 2, payload [129], checksum
+    final payload = MicrolifeProtocol.parseResponsePayload([77, 58, 0, 2, 129, 10]);
+    expect(payload, [129]);
+  });
+
+  test('rejects a frame with a bad header', () {
+    expect(MicrolifeProtocol.parseResponsePayload([77, 255, 0, 2, 129, 207]), isNull);
+  });
+
+  test('rejects a frame with a bad checksum', () {
+    expect(MicrolifeProtocol.parseResponsePayload([77, 58, 0, 2, 129, 11]), isNull);
+  });
+
+  test('rejects a frame with a mismatched length', () {
+    expect(MicrolifeProtocol.parseResponsePayload([77, 58, 0, 5, 129, 10]), isNull);
+  });
+}

--- a/app/test/features/bluetooth/ui/measurement_multiple_test.dart
+++ b/app/test/features/bluetooth/ui/measurement_multiple_test.dart
@@ -55,6 +55,7 @@ void main() {
     await tester.pumpWidget(materialApp(MeasurementMultiple(
       onClosed: () => tapCount++,
       onSelect: selected.add,
+      onSelectAll: (_) {},
       measurements: measurements,
     )));
 
@@ -82,5 +83,38 @@ void main() {
     await tester.tap(find.byIcon(Icons.close));
     await tester.pump();
     expect(tapCount, 1);
+  });
+
+  testWidgets('imports all measurements when import all is clicked', (WidgetTester tester) async {
+    final measurements = [
+      BleMeasurementData(
+        systolic: 123,
+        diastolic: 78,
+        meanArterialPressure: 90,
+        isMMHG: true,
+      ),
+      BleMeasurementData(
+        systolic: 124,
+        diastolic: 79,
+        meanArterialPressure: 91,
+        isMMHG: true,
+      ),
+    ];
+    List<BleMeasurementData>? importedAll;
+
+    await tester.pumpWidget(materialApp(MeasurementMultiple(
+      onClosed: () {},
+      onSelect: (_) {},
+      onSelectAll: (data) => importedAll = data,
+      measurements: measurements,
+    )));
+
+    final localizations = await AppLocalizations.delegate.load(const Locale('en'));
+    await tester.tap(find.text(localizations.importAll(measurements.length)));
+    await tester.pump();
+
+    expect(importedAll, isNotNull);
+    expect(importedAll!.length, 2);
+    expect(importedAll, containsAll(measurements));
   });
 }

--- a/app/test/features/input/forms/add_entry_form_test.dart
+++ b/app/test/features/input/forms/add_entry_form_test.dart
@@ -203,7 +203,7 @@ void main() {
 
     key.currentState!.fillForm((
       timestamp: time.add(Duration(hours: 1)),
-      intake: null, note: null, record: null, weight: null,
+      intake: null, note: null, record: null, weight: null, records: null
     ));
     await tester.pump();
     expect(key.currentState?.validate(), false);
@@ -217,7 +217,7 @@ void main() {
     key.currentState!.fillForm((
       timestamp: DateTime.now(),
       record: mockRecord(sys: 123123),
-      note: null, intake: null, weight: null,
+      note: null, intake: null, weight: null, records: null
     ));
     await tester.pump();
     expect(key.currentState?.validate(), false);
@@ -261,6 +261,7 @@ void main() {
       intake: intake,
       note: Note(time: intake.time, note: '123test', color: Colors.teal.toARGB32()),
       record: mockRecord(time: intake.time, sys: 123, dia: 45, pul: 67),
+      records: null,
       weight: BodyweightRecord(time: intake.time, weight: Weight.kg(123.45))
     );
     await tester.pumpWidget(materialApp(AddEntryForm(
@@ -288,6 +289,7 @@ void main() {
       intake: intake,
       note: Note(time: intake.time, note: '123test', color: Colors.teal.toARGB32()),
       record: mockRecord(time: intake.time, sys: 123, dia: 45, pul: 67),
+      records: null,
       weight: BodyweightRecord(time: intake.time, weight: Weight.kg(123.45))
     );
     await tester.pumpWidget(materialApp(AddEntryForm(
@@ -402,6 +404,7 @@ void main() {
         timestamp: DateTime.now(),
         weight: BodyweightRecord(time:  DateTime.now(), weight: Weight.kg(123.0)),
         record: null,
+        records: null,
         note: null,
         intake: null,
       ),
@@ -423,6 +426,7 @@ void main() {
         timestamp: initialTime,
         weight: null,
         record: null,
+        records: null,
         note: null,
         intake: null,
       ),
@@ -457,6 +461,7 @@ void main() {
         timestamp: initialTime,
         weight: null,
         record: null,
+        records: null,
         note: null,
         intake: null,
       ),

--- a/app/test/model/export_import/record_formatter_test.dart
+++ b/app/test/model/export_import/record_formatter_test.dart
@@ -162,6 +162,7 @@ AddEntryFormValue mockEntry({
       dia: dia == null ? null : Pressure.mmHg(dia),
       pul: pul,
     ),
+    records: null,
     note: Note(
       time: time,
       note: note,

--- a/docs/bluetooth.md
+++ b/docs/bluetooth.md
@@ -37,6 +37,7 @@ Most devices provide 2 ways to retrieve measurements over bluetooth, but there a
 | Yonker YK-BPW5                            |                                   | Yonker protocol |   ?    |                           |
 | Yongrow YK-IBPA1                          |                                   | Yonker protocol |   ?    |                           |
 | METIKO MT-YK-BPA1                         |                                   | Yonker protocol |   ?    |                           |
+| Microlife BP3GY1-2N                       | BP3GY1-2N                         | Microlife protocol | ? | Downloads all stored measurements |
 
 
 ## Specifications


### PR DESCRIPTION
I added support for the device I have - Microlife BP3GY1-2N. Basically ported from https://github.com/joergmlpts/blood-pressure-monitor. I also added a button to import all measurements from the device (Mine returns a list with every measurement and I wanted to import them all on first use). 