### PR TITLE
Make timestamp in export filename configurable

### DIFF
--- a/app/lib/features/export_import/ui/export_button.dart
+++ b/app/lib/features/export_import/ui/export_button.dart
@@ -56,7 +56,7 @@ void performExport(BuildContext context, bool share) async { // TODO: extract
   final localizations = AppLocalizations.of(context);
   final exportSettings = Provider.of<ExportSettings>(context, listen: false);
   _logger.fine('performExport - exportSettings=${exportSettings.toJson()}');
-  final filename = 'blood_press_${DateTime.now().toIso8601String()}';
+  final filename = exportSettings.addTimestamp ? 'blood_press_${DateTime.now().toIso8601String()}' : 'blood_press';
   switch (exportSettings.exportFormat) {
     case ExportFormat.db:
       final path = join(await getDatabasesPath(), 'bp.db');

--- a/app/lib/features/settings/export_import_screen.dart
+++ b/app/lib/features/settings/export_import_screen.dart
@@ -52,6 +52,15 @@ class ExportImportScreen extends StatelessWidget {
                   }
                 },
               ),
+            if (Platform.isAndroid) // only makes sense with exportDir, which is supported only for android
+              SwitchListTile(
+                title: Text(localizations.exportAddTimestamp),
+                subtitle: Text(localizations.exportAddTimestampDesc),
+                value: settings.addTimestamp,
+                onChanged: (value) {
+                  settings.addTimestamp = value;
+                },
+              ),
             SwitchListTile(
               title: Text(localizations.exportAfterEveryInput),
               subtitle: Text(localizations.exportAfterEveryInputDesc),

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -99,6 +99,8 @@
   },
   "exportImport": "Exportieren / Importieren",
   "exportDir": "Export Ordner",
+  "exportAddTimestamp": "Zeitstempel anhängen",
+  "exportAddTimestampDesc": "Einzigartiger Dateiname für jeden Export",
   "exportAfterEveryInput": "Export nach jedem Eintrag",
   "exportAfterEveryInputDesc": "Nicht empfohlen (datenexplosion)",
   "exportFormat": "Exportformat",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -100,6 +100,8 @@
   },
   "exportImport": "Export / Import",
   "exportDir": "Export directory",
+  "exportAddTimestamp": "Add timestamp to filename",
+  "exportAddTimestampDesc": "Ensures a unique filename for every export",
   "exportAfterEveryInput": "Export after every entry",
   "exportAfterEveryInputDesc": "Not recommended (file explosion)",
   "exportFormat": "Export format",

--- a/app/lib/model/storage/export_settings.dart
+++ b/app/lib/model/storage/export_settings.dart
@@ -15,6 +15,7 @@ class _ExportSettingsSpec extends ChangeNotifier {
   final Setting<ExportFormat> exportFormat = ExportFormatSetting(initialValue: ExportFormat.csv);
   final defaultExportDir = Setting<String>(initialValue: '');
   final exportAfterEveryEntry = Setting<bool>(initialValue: false);
+  final addTimestamp = Setting<bool>(initialValue: true);
   /// Presets defined by the user.
   final Setting<List<ExportPreset>> presets = ExportPresetListSetting();
   final Setting<List<String>> customPresetColumns = StringListSetting(initialValue: []);


### PR DESCRIPTION
Implements the proposal to allow a constant filename for exports (#709):
Adds a new export setting `addTimestamp` (default: `true`) to the ExportSettings and the respective option to the Export/Import screen. When `addTimestamp` is false, the data is exported to `blood_press.<ext>`. `en` and `de` localizations are updated.