### PR TITLE
Overwrite export file without timestamp

### DIFF
--- a/app/lib/features/export_import/ui/export_button.dart
+++ b/app/lib/features/export_import/ui/export_button.dart
@@ -215,6 +215,6 @@ Future<void> _exportData(BuildContext context, Uint8List data, String fullFileNa
   } else {
     _logger.fine('_exportData - Saving file using PersistentUserDirAccessAndroid');
     const userDir = PersistentUserDirAccessAndroid();
-    await userDir.writeFile(settings.defaultExportDir, fullFileName, mimeType, data);
+    await userDir.writeFile(settings.defaultExportDir, fullFileName, mimeType, data, true);
   }
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -863,10 +863,10 @@ packages:
     dependency: "direct main"
     description:
       name: persistent_user_dir_access_android
-      sha256: "6ce9fb8329b6b2463c29705cb5e382d77c0c945d311bd429fd752bfef81c92be"
+      sha256: ca727b8ed8bf4421142d5ef11a9bccc33d1abf0c2bced651b97e6698d7e0b395
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.2"
+    version: "0.0.3"
   petitparser:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   file_picker: ^11.0.2
   app_settings: ^7.0.0
   logging: ^1.3.0
-  persistent_user_dir_access_android: ^0.0.2
+  persistent_user_dir_access_android: ^0.0.3
   share_plus: ^12.0.2
   sqflite_common_ffi: ^2.4.0+3
   inline_tab_view: ^1.0.2


### PR DESCRIPTION
Following up the discussion in #711, this PR updates [persistent_user_dir_access_android to 0.0.3](https://github.com/derdilla/persistent_user_dir_access_android/releases/tag/v0.0.3) and uses the new `overwrite` argument when writing out the export file.

I've re-tested the export behaviour with `addTimestamp == true` and on the android emulator it now overwrites the file as expected.