### PR TITLE
Bluetooth connection: wait before subscribing to measurements

### DIFF
--- a/app/lib/features/bluetooth/logic/ble_read_cubit.dart
+++ b/app/lib/features/bluetooth/logic/ble_read_cubit.dart
@@ -36,6 +36,9 @@ class BleReadCubit extends Cubit<BleReadState> with TypeLogger {
   static const microlifeNotifyCharacteristicUUID = 'fff1';
   static const microlifeWriteCharacteristicUUID = 'fff2';
 
+  /// How long to let a freshly connected device settle before subscribing.
+  static const _settleDelay = Duration(milliseconds: 100);
+
   /// Maximum number of bytes to be written to the device in a single GATT write.
   static const _microlifeWriteChunkSize = 20;
 
@@ -113,6 +116,9 @@ class BleReadCubit extends Cubit<BleReadState> with TypeLogger {
       emit(BleReadSuccess(decodedData));
 
     } else if (canIndicate) {
+      // Beurer BM85 seems to need some rest between service discovery and subscribing or it will stay silent.
+      await Future<void>.delayed(_settleDelay);
+
       final completer = Completer<void>();
       final data = <BleMeasurementData>[];
       final connectionSubscription = cm.connectionStateChanged.listen((e) {


### PR DESCRIPTION
A Beurer BM85 sometimes seems to ignore a subscription when it arrives right after service discovery: it acknowledges the descriptor write and then never sends anything, instead it shows an Error on screen and stalls the connection, which then dies of a supervision timeout.

The issue only appears on the second reading attempt without app restart which could also be caused by some internal state mixup within the app, but I could not narrow it down any further.
Deferring by an event loop iteration is not enough, 50ms already are, so wait 100ms to keep some margin.