### PR TITLE
Read the measurement status flags from the correct bit positions

### DIFF
--- a/app/lib/features/bluetooth/logic/characteristics/ble_measurement_status.dart
+++ b/app/lib/features/bluetooth/logic/characteristics/ble_measurement_status.dart
@@ -12,12 +12,13 @@ class BleMeasurementStatus {
   });
 
   factory BleMeasurementStatus.decode(int byte) => BleMeasurementStatus(
-    bodyMovementDetected: isBitIntByteSet(byte, 1),
-    cuffTooLose: isBitIntByteSet(byte, 2),
-    irregularPulseDetected: isBitIntByteSet(byte, 3),
-    pulseRateInRange: (byte & (1 << 4) >> 3) == 0,
-    pulseRateExceedsUpperLimit: (byte & (1 << 4) >> 3) == 1,
-    pulseRateIsLessThenLowerLimit: (byte & (1 << 4) >> 3) == 2,
+    bodyMovementDetected: isBitIntByteSet(byte, 0),
+    cuffTooLose: isBitIntByteSet(byte, 1),
+    irregularPulseDetected: isBitIntByteSet(byte, 2),
+    // Bits 3 and 4 form the pulse rate range: 0 within, 1 above, 2 below.
+    pulseRateInRange: ((byte >> 3) & 0x3) == 0,
+    pulseRateExceedsUpperLimit: ((byte >> 3) & 0x3) == 1,
+    pulseRateIsLessThenLowerLimit: ((byte >> 3) & 0x3) == 2,
     improperMeasurementPosition: isBitIntByteSet(byte, 5),
   );
 

--- a/app/test/features/bluetooth/logic/characteristics/ble_measurement_data_test.dart
+++ b/app/test/features/bluetooth/logic/characteristics/ble_measurement_data_test.dart
@@ -25,4 +25,34 @@ void main() {
     expect(result.status?.pulseRateIsLessThenLowerLimit, false);
     expect(result.status?.improperMeasurementPosition, false);
   });
+
+  test('decodes the measurement status flags', () {
+    // Status byte 39 => 0010 0111: body movement, cuff too loose, irregular
+    // pulse and an improper measurement position.
+    final result = BleMeasurementData.decode(Uint8List.fromList(
+        [22, 124, 0, 86, 0, 97, 0, 232, 7, 6, 15, 17, 17, 27, 51, 0, 39, 0]));
+
+    expect(result, isNotNull);
+    expect(result!.status?.bodyMovementDetected, true);
+    expect(result.status?.cuffTooLose, true);
+    expect(result.status?.irregularPulseDetected, true);
+    expect(result.status?.improperMeasurementPosition, true);
+    expect(result.status?.pulseRateInRange, true);
+  });
+
+  test('decodes the pulse rate range from the status flags', () {
+    // Bits 3 and 4 hold the range: 1 => above, 2 => below the limit.
+    final above = BleMeasurementData.decode(Uint8List.fromList(
+        [22, 124, 0, 86, 0, 97, 0, 232, 7, 6, 15, 17, 17, 27, 51, 0, 8, 0]));
+    final below = BleMeasurementData.decode(Uint8List.fromList(
+        [22, 124, 0, 86, 0, 97, 0, 232, 7, 6, 15, 17, 17, 27, 51, 0, 16, 0]));
+
+    expect(above?.status?.pulseRateExceedsUpperLimit, true);
+    expect(above?.status?.pulseRateIsLessThenLowerLimit, false);
+    expect(above?.status?.pulseRateInRange, false);
+
+    expect(below?.status?.pulseRateIsLessThenLowerLimit, true);
+    expect(below?.status?.pulseRateExceedsUpperLimit, false);
+    expect(below?.status?.pulseRateInRange, false);
+  });
 }


### PR DESCRIPTION
According to the spec, every flag was read one bit too high, so bodyMovementDetected reported the cuff fit, cuffTooLose the irregular pulse and so on.

The pulse rate range was off as well: `>>` has precedence over `&`, so `byte & (1 << 4) >> 3` masked bit 1 instead of shifting bits 3 and 4 into place so the result could never equal 1.