### PR TITLE
Add quirks for some Beurer devices (tested with BM85)

### DIFF
--- a/app/lib/features/bluetooth/logic/ble_read_cubit.dart
+++ b/app/lib/features/bluetooth/logic/ble_read_cubit.dart
@@ -19,12 +19,17 @@ class BleReadCubit extends Cubit<BleReadState> with TypeLogger {
   BleReadCubit({
     required this.device,
     required this.cm,
+    this.deviceName,
   }): super(BleReadInProgress());
 
   /// Bluetooth device to connect to.
   final Peripheral device;
 
   final CentralManager cm;
+
+  /// Advertised name of [device], used to detect devices that deviate from the
+  /// GATT spec (currently some Beurer devices, see [isKnownBigEndianDevice]).
+  final String? deviceName;
 
   static const defaultServiceUUID = '1810';
   static const defaultCharacteristicUUID = '2A35';
@@ -45,6 +50,19 @@ class BleReadCubit extends Cubit<BleReadState> with TypeLogger {
   static const _microlifeResponseTimeout = Duration(seconds: 30);
   final List<int> _microlifeResponseByteBuffer = [];
   Completer<Uint8List>? _microlifePendingResponse;
+
+  /// Whether [advertisedName] belongs to a model known to send multi byte
+  /// fields big endian instead of the little endian the spec requires.
+  ///
+  /// Currently supports some Beurer devices. The official Beurer app keeps the same list
+  /// of models and uses it to pick between the byte orders.
+  @visibleForTesting
+  static bool isKnownBigEndianDevice(String? advertisedName) {
+    if (advertisedName == null) return false;
+    final normalized = advertisedName.toUpperCase().replaceAll(RegExp(r'[^A-Z0-9]'), '');
+    return const ['BM48', 'BM59', 'BM85', 'ELITE900']
+        .any(normalized.contains);
+  }
 
   Future<bool> _connectDevice() async {
     logger.info('Connecting to ${device.uuid}');
@@ -112,12 +130,18 @@ class BleReadCubit extends Cubit<BleReadState> with TypeLogger {
       return;
     }
 
+    // The known big endian models also always send the user id without setting
+    // its flag, so one device check drives both quirks.
+    final bigEndian = isKnownBigEndianDevice(deviceName);
+    logger.finer('reading GATT data from $deviceName (bigEndian: $bigEndian)');
+
     // Read or indicate data;
     final canRead = characteristic.properties.contains(GATTCharacteristicProperty.read);
     final canIndicate = characteristic.properties.contains(GATTCharacteristicProperty.indicate);
     if (canRead) {
       final data = await cm.readCharacteristic(device, characteristic);
-      final decodedData = BleMeasurementData.decode(data);
+      final decodedData = BleMeasurementData.decode(data,
+          bigEndian: bigEndian, alwaysSendsUserId: bigEndian);
       if (decodedData == null) {
         logger.warning('Failed to decode GATT measurement $data for $device');
         emit(BleReadFailure('Could not decode data'));
@@ -139,7 +163,8 @@ class BleReadCubit extends Cubit<BleReadState> with TypeLogger {
       final dataSubscription = cm.characteristicNotified
           .where((e) => e.characteristic == characteristic
                   && e.peripheral == device)
-          .map((e) => BleMeasurementData.decode(e.value))
+          .map((e) => BleMeasurementData.decode(e.value,
+              bigEndian: bigEndian, alwaysSendsUserId: bigEndian))
           .listen((e) { if (e != null) data.add(e); },
               onDone: () {
                 if (!completer.isCompleted) completer.complete();

--- a/app/lib/features/bluetooth/logic/characteristics/ble_measurement_data.dart
+++ b/app/lib/features/bluetooth/logic/characteristics/ble_measurement_data.dart
@@ -37,7 +37,15 @@ class BleMeasurementData {
     );
 
   /// Decode bytes read from the characteristic into a [BleMeasurementData]
-  static BleMeasurementData? decode(Uint8List data) {
+  ///
+  /// Some devices deviate from the spec. The caller recognizes those devices by
+  /// name and opts into the quirks they need: [bigEndian] for multi byte fields
+  /// sent in the wrong byte order, [alwaysSendsUserId] for a user id that is
+  /// present without its flag being set.
+  static BleMeasurementData? decode(Uint8List data, {
+    bool bigEndian = false,
+    bool alwaysSendsUserId = false,
+  }) {
     // https://github.com/NordicSemiconductor/Kotlin-BLE-Library/blob/6b565e59de21dfa53ef80ff8351ac4a4550e8d58/profile/src/main/java/no/nordicsemi/android/kotlin/ble/profile/bps/BloodPressureMeasurementParser.kt
 
     // Reading specific bits: `(byte & (1 << bitIdx))`
@@ -55,7 +63,8 @@ class BleMeasurementData {
     final bool isMMHG = !isBitIntByteSet(flagsByte, 0); // 0 => mmHg 1 =>kPA
     final bool timestampPresent = isBitIntByteSet(flagsByte, 1);
     final bool pulseRatePresent = isBitIntByteSet(flagsByte, 2);
-    final bool userIdPresent = isBitIntByteSet(flagsByte, 3);
+    // Some Beurer devices always send the user id, without setting the flag for it.
+    final bool userIdPresent = isBitIntByteSet(flagsByte, 3) || alwaysSendsUserId;
     final bool measurementStatusPresent = isBitIntByteSet(flagsByte, 4);
 
     if (data.length < (7
@@ -88,7 +97,7 @@ class BleMeasurementData {
 
     double? pulse;
     if (pulseRatePresent) {
-      pulse = readSFloat(data, offset);
+      pulse = bigEndian ? readSFloatBe(data, offset) : readSFloat(data, offset);
       offset += 2;
     }
 
@@ -100,7 +109,12 @@ class BleMeasurementData {
 
     BleMeasurementStatus? status;
     if (measurementStatusPresent) {
-      status = BleMeasurementStatus.decode(data[offset]);
+      // The status field is a uint16. Some Beurer devices send it big endian
+      // instead of the little endian the spec requires.
+      final int? statusValue = bigEndian
+        ? readUInt16Be(data, offset)
+        : readUInt16Le(data, offset);
+      if (statusValue != null) status = BleMeasurementStatus.decode(statusValue);
     }
 
     return BleMeasurementData(

--- a/app/lib/features/bluetooth/logic/characteristics/ble_measurement_status.dart
+++ b/app/lib/features/bluetooth/logic/characteristics/ble_measurement_status.dart
@@ -11,15 +11,21 @@ class BleMeasurementStatus {
     required this.improperMeasurementPosition,
   });
 
-  factory BleMeasurementStatus.decode(int byte) => BleMeasurementStatus(
-    bodyMovementDetected: isBitIntByteSet(byte, 0),
-    cuffTooLose: isBitIntByteSet(byte, 1),
-    irregularPulseDetected: isBitIntByteSet(byte, 2),
+  /// Decode the 16 bit measurement status field into a [BleMeasurementStatus].
+  ///
+  /// [value] is the whole uint16 field, not just its low byte. The spec only
+  /// assigns bits 0 to 5; bits 6 to 15 are reserved for future use and are
+  /// ignored here. Callers are responsible for reading [value] in the byte
+  /// order the device uses.
+  factory BleMeasurementStatus.decode(int value) => BleMeasurementStatus(
+    bodyMovementDetected: isBitIntByteSet(value, 0),
+    cuffTooLose: isBitIntByteSet(value, 1),
+    irregularPulseDetected: isBitIntByteSet(value, 2),
     // Bits 3 and 4 form the pulse rate range: 0 within, 1 above, 2 below.
-    pulseRateInRange: ((byte >> 3) & 0x3) == 0,
-    pulseRateExceedsUpperLimit: ((byte >> 3) & 0x3) == 1,
-    pulseRateIsLessThenLowerLimit: ((byte >> 3) & 0x3) == 2,
-    improperMeasurementPosition: isBitIntByteSet(byte, 5),
+    pulseRateInRange: ((value >> 3) & 0x3) == 0,
+    pulseRateExceedsUpperLimit: ((value >> 3) & 0x3) == 1,
+    pulseRateIsLessThenLowerLimit: ((value >> 3) & 0x3) == 2,
+    improperMeasurementPosition: isBitIntByteSet(value, 5),
   );
 
   final bool bodyMovementDetected;

--- a/app/lib/features/bluetooth/logic/characteristics/decoding_util.dart
+++ b/app/lib/features/bluetooth/logic/characteristics/decoding_util.dart
@@ -17,6 +17,12 @@ double? readSFloat(List<int> data, int offset) {
   return (mantissa * (pow(10, exponent))).toDouble();
 }
 
+/// Attempts to read a byte swapped IEEE-11073 16bit SFloat at data[offset].
+double? readSFloatBe(List<int> data, int offset) {
+  if (data.length < offset + 2) return null;
+  return readSFloat([data[offset + 1], data[offset]], 0);
+}
+
 int? readUInt8(List<int> data, int offset) {
   if (data.length < offset + 1) return null;
   return data[offset];

--- a/app/lib/features/bluetooth/logic/device_scan_cubit.dart
+++ b/app/lib/features/bluetooth/logic/device_scan_cubit.dart
@@ -80,7 +80,8 @@ class DeviceScanCubit extends Cubit<DeviceScanState> with TypeLogger {
     if (preferred != null) {
       final readCubit = BleReadCubit(
         device: preferred.source.peripheral,
-        cm: preferred.manager
+        cm: preferred.manager,
+        deviceName: preferred.name,
       );
       emit(DeviceSelected(readCubit));
       _stopScanning().ignore();
@@ -112,7 +113,8 @@ class DeviceScanCubit extends Cubit<DeviceScanState> with TypeLogger {
 
     final cubit = BleReadCubit(
         device: device.source.peripheral,
-        cm: device.manager
+        cm: device.manager,
+        deviceName: device.name,
     );
     emit(DeviceSelected(cubit));
     cubit.takeMeasurement()

--- a/app/test/features/bluetooth/logic/ble_read_cubit_test.dart
+++ b/app/test/features/bluetooth/logic/ble_read_cubit_test.dart
@@ -1,3 +1,6 @@
+import 'package:blood_pressure_app/features/bluetooth/logic/ble_read_cubit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
 /*import 'package:blood_pressure_app/features/bluetooth/ble_read_cubit.dart';
 import 'package:blood_pressure_app/logging.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
@@ -13,6 +16,14 @@ import 'package:mockito/mockito.dart';
 import 'ble_read_cubit_test.mocks.dart';*/
 
 void main() {
+  test('detects devices that send big endian measurements', () {
+    expect(BleReadCubit.isKnownBigEndianDevice('Beurer BM85'), true);
+    expect(BleReadCubit.isKnownBigEndianDevice('BM59'), true);
+    expect(BleReadCubit.isKnownBigEndianDevice('Elite 900'), true);
+    expect(BleReadCubit.isKnownBigEndianDevice('Beurer BM96'), false);
+    expect(BleReadCubit.isKnownBigEndianDevice(null), false);
+  });
+
   // TODO: test once practice shows there are no flaws in these goals:
   // - success path works
   // - should fail when device not connected

--- a/app/test/features/bluetooth/logic/characteristics/ble_measurement_data_test.dart
+++ b/app/test/features/bluetooth/logic/characteristics/ble_measurement_data_test.dart
@@ -55,4 +55,45 @@ void main() {
     expect(below?.status?.pulseRateExceedsUpperLimit, false);
     expect(below?.status?.pulseRateInRange, false);
   });
+
+  test('decodes beurer sample data', () {
+    // Recorded from a Beurer BM85.
+    final result = BleMeasurementData.decode(Uint8List.fromList(
+        [86, 106, 0, 71, 0, 0, 0, 234, 7, 8, 11, 18, 31, 0, 0, 63, 0, 0, 0]),
+        bigEndian: true, alwaysSendsUserId: true);
+
+    expect(result, isNotNull);
+    expect(result!.systolic, 106.0);
+    expect(result.diastolic, 71.0);
+    expect(result.isMMHG, true);
+    expect(result.pulse, 63.0);
+    expect(result.userID, 0);
+    expect(result.timestamp, DateTime(2026, 08, 11, 18, 31));
+  });
+
+  test('decodes beurer sample data of the second user', () {
+    final result = BleMeasurementData.decode(Uint8List.fromList(
+        [86, 113, 0, 73, 0, 0, 0, 234, 7, 8, 11, 20, 56, 0, 0, 65, 1, 0, 0]),
+        bigEndian: true, alwaysSendsUserId: true);
+
+    expect(result, isNotNull);
+    expect(result!.systolic, 113.0);
+    expect(result.diastolic, 73.0);
+    expect(result.pulse, 65.0);
+    expect(result.userID, 1);
+    expect(result.timestamp, DateTime(2026, 08, 11, 20, 56));
+  });
+
+  test('decodes beurer sample data of the second user with a high pulse', () {
+    final result = BleMeasurementData.decode(Uint8List.fromList(
+        [86, 119, 0, 70, 0, 0, 0, 234, 7, 8, 11, 20, 57, 0, 0, 87, 1, 0, 64]),
+        bigEndian: true, alwaysSendsUserId: true);
+
+    expect(result, isNotNull);
+    expect(result!.systolic, 119.0);
+    expect(result.diastolic, 70.0);
+    expect(result.pulse, 87.0);
+    expect(result.userID, 1);
+    expect(result.timestamp, DateTime(2026, 08, 11, 20, 57));
+  });
 }

--- a/docs/bluetooth.md
+++ b/docs/bluetooth.md
@@ -33,6 +33,7 @@ Most devices provide 2 ways to retrieve measurements over bluetooth, but there a
 | Omron X2 Smart+                           | X2 Smart+                         |  Standard GATT  |   ✅    |                           |
 | Omron Bronze BP5150                       | BLESmart_(long identifier string) |  Standard GATT  |   ✅    |                           |
 | Beurer BM59                               | BM 59                             |  Standard GATT  |   ✅    |      Reads multiple       |
+| Beurer BM85                               | Beurer BM85                       |  Standard GATT  |   ✅    |      Reads multiple       |
 | Yonker YK-IBPA1                           |                                   | Yonker protocol |   ✅    | Connect after measurement |
 | Yonker YK-BPW5                            |                                   | Yonker protocol |   ?    |                           |
 | Yongrow YK-IBPA1                          |                                   | Yonker protocol |   ?    |                           |


### PR DESCRIPTION
The Beurer BM85 and probably also some other Beurer models send the pulse and measurement flags in reversed byte order. Follow the approach of the official app and keep a list of devices known to violate the spec, which then get special treatment during decoding.

This has so far only been tested with a Beurer BM85!
